### PR TITLE
ci: add lint, pr, and release workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,16 @@
+name: Lint
+
+on:
+  pull_request: {}
+
+jobs:
+  golangci:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          only-new-issues: true
+          args: --timeout=5m # 1m is not enough, experimentally.

--- a/.github/workflows/push-pr-release.yaml
+++ b/.github/workflows/push-pr-release.yaml
@@ -1,0 +1,41 @@
+name: Build
+
+on:
+  pull_request: {}
+  release:
+    types: [ published ]
+
+# Needed to upload assets to releases.
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [ linux ]
+        goarch: [ amd64, arm64 ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract k6 version from go.mod
+        id: version
+        run: |-
+          k6version=$(grep -e go.k6.io go.mod | cut -d' ' -f 2)
+          echo "Detected k6 version: ${k6version}"
+          echo "k6=${k6version}" >> $GITHUB_OUTPUT
+      - name: Build with xk6
+        run: |-
+          docker run --rm -i -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" \
+            -e "GOOS=${{ matrix.goos }}" -e "GOARCH=${{ matrix.goarch }}" \
+            grafana/xk6 build ${{ steps.version.outputs.k6 }} \
+            --output "dist/sm-k6-${{ matrix.goos }}-${{ matrix.goarch }}" \
+            --with sm=.
+
+      - name: Upload artifact to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |-
+          gh release upload "${{ github.ref_name }}" dist/* --clobber

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # xk6-sm
 
 Output k6 extension used by the [synthetic monitoring agent](https://github.com/grafana/synthetic-monitoring-agent).
+
+## Build
+
+Use [xk6](https://github.com/grafana/xk6). See the CI/CD pipelines for a full example of a build command.
+
+## Release process
+
+Create a release using the GitHub UI or `gh create release`. A CI/CD pipeline will build the artifacts and attach them to the release.


### PR DESCRIPTION
This PR adds CI/CD workflows to this repo, namely a lint pipeline and a build/release pipeline.

The build/release pipeline is unified to avoid complex command duplication, and instead it just skips the uploading step if the context is that of a PR instead of a release being created.