### PR TITLE
k6/x/sm JavaScript module registration disabled due to #30

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -9,9 +9,10 @@ import (
 	"go.k6.io/k6/metrics"
 )
 
-func init() {
-	modules.Register("k6/x/sm", NewRootModule())
-}
+// registration disabled due to: https://github.com/grafana/xk6-sm/issues/30
+// func init() {
+// 	 modules.Register("k6/x/sm", NewRootModule())
+// }
 
 type RootModule struct{}
 


### PR DESCRIPTION
The `k6/x/sm` JavaScript module registration disabled due to #30 
