### PR TITLE
feat: refactor metrics processing

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -294,6 +294,13 @@ func TestSMK6(t *testing.T) {
 				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles/"},
 				assertValue:  func(f float64) bool { return f >= 1.1 },
 			},
+			{
+				name:       "TLS version label value",
+				metricName: "probe_http_info",
+				// Test for a paticular URL to avoid matching a failed request, which has no TLS version.
+				metricLabels: map[string]string{"tls_version": "1.3", "url": "https://test-api.k6.io/public/crocodiles/"},
+				assertValue:  any, // Just fail if not present.
+			},
 		} {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -152,8 +152,6 @@ func TestSMK6(t *testing.T) {
 		// If a metric contains a label (key), and that metric is not in the list (value), the test fails.
 		type exceptForMetrics []string
 		forbiddenLabels := map[string]exceptForMetrics{
-			"tls_version":       {"probe_http_info"},
-			"proto":             {"probe_http_info"},
 			"error":             {"probe_http_info"},
 			"expected_response": {"probe_http_got_expected_response"},
 			"group":             {},

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -304,6 +304,8 @@ func TestSMK6(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
 				matchedMetrics := 0
 				for _, mf := range mfs {
 					if *mf.Name != tc.metricName {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -83,7 +83,8 @@ func TestSMK6(t *testing.T) {
 			"probe_http_error_code",
 			"probe_http_got_expected_response",
 			"probe_http_info",
-			"probe_http_requests_failed_total",
+			"probe_http_requests_failed",       // Original rate.
+			"probe_http_requests_failed_total", // Computed counter.
 			"probe_http_requests_total",
 			"probe_http_ssl",
 			"probe_http_status_code",
@@ -107,7 +108,7 @@ func TestSMK6(t *testing.T) {
 
 		unwantedMetrics := []string{
 			"probe_checks",
-			"probe_http_reqs", "probe_http_req_failed",
+			"probe_http_reqs", "probe_http_req_failed", // Renamed s/req/requests.
 			"probe_data_sent", "probe_data_received",
 			"probe_http_req_duration", "probe_iteration_duration",
 			"probe_http_req_blocked", "probe_http_req_connecting", "probe_http_req_receiving", "probe_http_req_sending", "probe_http_req_tls_handshaking", "probe_http_req_waiting",
@@ -282,9 +283,28 @@ func TestSMK6(t *testing.T) {
 				assertValue:  equals(0),
 			},
 			{
-				name:        "Total requests for each url",
-				metricName:  "probe_http_requests_total",
-				assertValue: equals(1),
+				name:         "Total requests for a URL accessed once",
+				metricName:   "probe_http_requests_total",
+				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles/"},
+				assertValue:  equals(1),
+			},
+			{
+				name:         "Total requests for a URL accessed twice",
+				metricName:   "probe_http_requests_total",
+				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles4/"},
+				assertValue:  equals(2),
+			},
+			{
+				name:         "HTTP requests failed rate",
+				metricName:   "probe_http_requests_failed",
+				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles4/"},
+				assertValue:  equals(1),
+			},
+			{
+				name:         "HTTP requests failed ttoal",
+				metricName:   "probe_http_requests_failed_total",
+				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles4/"},
+				assertValue:  equals(2),
 			},
 			{
 				name:         "HTTP version",

--- a/integration/test-script.js
+++ b/integration/test-script.js
@@ -41,5 +41,6 @@ export default function () {
   http.get(`https://${testHost}/public/crocodiles2/`); // 404
   http.get(`https://${testHost}/public/crocodiles3/`); // 404
   http.get(`https://${testHost}/public/crocodiles4/`); // 404
+  http.get(`https://${testHost}/public/crocodiles4/`); // Second 404, to assert differences between failure rate and counter.
   http.get(`http://fail.internal/public/crocodiles4/`); // failed
 }

--- a/output.go
+++ b/output.go
@@ -223,6 +223,20 @@ func (ms *metricStore) DeriveMetrics() {
 				log.Tracef("Created %q from %q", errorCodeTS.name, ts.name)
 			}()
 
+			// TODO: We should revisit this. This keeps the old behavior, but I'm not sure having the status code as the
+			// value of a gauge is actually useful.
+			func() {
+				strCode, _ := ts.tags.Get("status")
+				newValue, _ := strconv.ParseFloat(strCode, 32)
+				statusCodeTS := timeseries{
+					name:       "http_status_code",
+					metricType: metrics.Gauge,
+					tags:       ts.tags,
+				}
+				ms.store[statusCodeTS] = value{newValue, 1}
+				log.Tracef("Created %q from %q", statusCodeTS.name, ts.name)
+			}()
+
 		// Rename to http_requests_failed_total
 		case "http_req_failed":
 			newTS := ts

--- a/output.go
+++ b/output.go
@@ -392,12 +392,6 @@ func (ms *metricStore) RemoveLabels() {
 			ts.tags = ts.tags.Without("proto")
 		}
 
-		if ts.name != "http_requests_total" {
-			// Keep status label only on total requests.
-			log.Tracef("Removing status label from %q", ts.name)
-			ts.tags = ts.tags.Without("status")
-		}
-
 		// The documentation at https://k6.io/docs/using-k6/tags-and-groups/ seems to suggest that
 		// "group" should not be empty (it shouldn't be there if there's a single group), but I keep
 		// seeing instances of an empty group name.

--- a/output.go
+++ b/output.go
@@ -369,8 +369,9 @@ func (ms *metricStore) RemoveMetrics() {
 	// the full slice does not fit on a cache line.
 	deletable := map[string]bool{
 		// Not useful in SM context:
-		"vus":     true,
-		"vus_max": true,
+		"vus":        true,
+		"vus_max":    true,
+		"iterations": true,
 		// Replaced by version with _bytes suffix:
 		"data_sent":     true,
 		"data_received": true,

--- a/output.go
+++ b/output.go
@@ -237,6 +237,18 @@ func (ms *metricStore) DeriveMetrics() {
 				log.Tracef("Created %q from %q", statusCodeTS.name, ts.name)
 			}()
 
+			func() {
+				strCode, _ := ts.tags.Get("proto")
+				newValue, _ := strconv.ParseFloat(strings.TrimPrefix(strCode, "HTTP/"), 32)
+				httpVersionTS := timeseries{
+					name:       "http_version",
+					metricType: metrics.Gauge,
+					tags:       ts.tags,
+				}
+				ms.store[httpVersionTS] = value{newValue, 1}
+				log.Tracef("Created %q from %q", httpVersionTS.name, ts.name)
+			}()
+
 		// Rename to http_requests_failed_total
 		case "http_req_failed":
 			newTS := ts

--- a/output.go
+++ b/output.go
@@ -368,6 +368,9 @@ func (ms *metricStore) RemoveLabels() {
 		ts.tags = ts.tags.Without("error_code")
 		ts.tags = ts.tags.Without("expected_response")
 
+		// High cardinality label. This is already present in logs.
+		ts.tags = ts.tags.Without("error")
+
 		newStore[ts] = v
 	}
 

--- a/output.go
+++ b/output.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/mstoykov/atlas"
 	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/metrics"
 	"go.k6.io/k6/output"
@@ -18,18 +19,386 @@ import (
 
 const (
 	ExtensionName = "sm"
-	RawURLTagName = "__raw_url__"
 )
 
 func init() {
 	output.RegisterExtension(ExtensionName, New)
 }
 
+// Value stores the value of a timeseries, after aggregation.
+// Samples are aggregated into a single value as they arrive, as in SM context we are not interested in keeping more
+// than one datapoint per timeseries.
+type value struct {
+	// value contains the numeric value of the metric, after aggregation.
+	value float64
+	// seenSamples stores the number of samples seen from the metric. This is used to perform averages in constant
+	// space, that is, without storing the full list of seen samples.
+	seenSamples int
+}
+
+// timeseries is a simplified version of k6 [metrics.TimeSeries].
+// It can be used as a map key for the same reason [metrics.TimeSeries] can: [metrics.TagSet] is immutable (modifying it
+// clones it and returns a new pointer), and k6 promises to always reuse the same TagSet instance instance for each
+// given timeseries whose TagSet contents are the same.
+type timeseries struct {
+	name       string
+	metricType metrics.MetricType
+	tags       *metrics.TagSet
+}
+
+// timeseriesFromK6 simplifies k6's [metrics.TimeSeries] into timeseries.
+//
+// Equality of the arguments is preserved: If t1 t2 are of type [metrics.TimeSeries], and t1 == t2, then
+// timeseriesFromK6(t1) == timeseriesFromK6(t2).
+func timeseriesFromK6(k6Ts metrics.TimeSeries) timeseries {
+	return timeseries{
+		name:       k6Ts.Metric.Name,
+		metricType: k6Ts.Metric.Type,
+		tags:       k6Ts.Tags,
+	}
+}
+
+// metricStore stores and processes k6 samples according to SM needs. It can aggregate samples as they arrive in
+// constant memory, and peform post-processing (metric renaming and manipulation) when k6 is done executing and all
+// samples have been aggregated.
+//
+// Post-processing does four things:
+// - Derive new timeseries from existing ones, in a 1:N mapping. This includes cloning timeseries under new names,
+// changing units, or creating new metrics from labels, for example.
+// - Derive logs from timeseries.
+// - Remove specific timeseries.
+// - Remove specific labels from specific timeseries.
+//
+// Post-processing implemented here cannot do:
+// - Promql-like aggregations, e.g. aggregate multiple timeseries into one
+// - N:M or N:1 metric mappings
+//
+// TODO: We need to store samples on a map in order to perform the aggregation efficiently, but for the post-processing
+// step, where the map of metrics is simply walked through, a slice would be faster. Converting the map to slice before
+// post-processing would be a good performance optimization to make here.
+type metricStore struct {
+	logger logrus.FieldLogger
+	mtx    sync.Mutex
+	store  map[timeseries]value
+}
+
+func newMetricStore(size int) *metricStore {
+	logger := logrus.New()
+	logger.Out = io.Discard
+
+	return &metricStore{
+		store:  make(map[timeseries]value, size),
+		logger: logger,
+	}
+}
+
+func (ms *metricStore) Len() int {
+	return len(ms.store)
+}
+
+// Record inserts a new sample into the store in a thread-safe way, aggregating it if the timeseries was already present
+// in the metricStore.
+// Record locks a mutex, and thus should be as fast as k6's SampleBuffer.
+func (ms *metricStore) Record(sample metrics.Sample) {
+	log := ms.logger.WithField("step", "record")
+
+	ts := timeseriesFromK6(sample.TimeSeries)
+
+	ms.mtx.Lock()
+	defer ms.mtx.Unlock()
+
+	old, found := ms.store[ts]
+	if !found {
+		// Timeseries not already in store, just add it.
+		ms.store[ts] = value{
+			value:       sample.Value,
+			seenSamples: 1,
+		}
+
+		return
+	}
+
+	log.Tracef("Aggregating sample (%f) for %q into existing (%f) value", sample.Value, ts.name, old.value)
+
+	updated := old
+	switch ts.metricType {
+	case metrics.Counter:
+		// Sum values.
+		updated.value += sample.Value
+
+	case metrics.Trend, metrics.Rate:
+		// Compute the average.
+		updated.value = ((old.value * float64(old.seenSamples)) + sample.Value) / (float64(old.seenSamples) + 1)
+
+	case metrics.Gauge:
+		// Replace with newest.
+		updated.value = sample.Value
+	default:
+		log.Tracef("Unknown metric type %q for %q, keeping previous sample without aggregating", ts.metricType, ts.name)
+		return
+	}
+
+	updated.seenSamples++
+	ms.store[ts] = updated
+}
+
+// DeriveMetrics creates new metrics from existing ones. These metrics are created either to have some consistency with
+// other SM checks, or as a preparation step to set labels on them that will then be removed from others.
+// Metrics are derived sequentially, on a single pass. This means that DeriveMetrics can only be extended to derive
+// metrics in a 1:N fashion, where one existing metric produces N derived metrics. DeriveMetrics cannot aggregate
+// multiple metrics into one.
+func (ms *metricStore) DeriveMetrics() {
+	log := ms.logger.WithField("step", "deriveMetrics")
+
+	for ts, v := range ms.store {
+		// Range over the existing metrics and create new ones, adding them to the map on the fly. This is safe as per
+		// the go spec, with the only caveat that whether new values will be iterated over is undefined. We do not care
+		// about that.
+		// We need to range over the map instead of fetching these metrics directly, as each metric may appear multiple
+		// time with different labels (e.g. different URLs).
+		// Inline funcs are used to scope variables and avoid copy-paste bugs.
+		switch ts.name {
+		// Create specific metrics containing info about http calls.
+		// Additionally, clone this metric as http_requests_total.
+		case "http_reqs":
+			func() {
+				renamedTS := timeseries{
+					name:       "http_requests_total",
+					metricType: metrics.Counter,
+					tags:       ts.tags,
+				}
+				ms.store[renamedTS] = v
+				log.Tracef("Created %q from %q", renamedTS.name, ts.name)
+			}()
+
+			func() {
+				infoTS := timeseries{
+					name:       "http_info",
+					metricType: metrics.Gauge,
+					tags:       ts.tags,
+				}
+				ms.store[infoTS] = value{1, 1}
+				log.Tracef("Created %q from %q", infoTS.name, ts.name)
+			}()
+
+			func() {
+				newValue := 0.0
+				if _, found := ts.tags.Get("tls_version"); found {
+					newValue = 1.0
+				}
+
+				sslTS := timeseries{
+					name:       "http_ssl",
+					metricType: metrics.Gauge,
+					tags:       ts.tags,
+				}
+				ms.store[sslTS] = value{newValue, 1}
+				log.Tracef("Created %q from %q", sslTS.name, ts.name)
+			}()
+
+			func() {
+				newValue := 0.0
+				if expected, _ := ts.tags.Get("expected_response"); expected == "true" {
+					newValue = 1.0
+				}
+
+				responseTS := timeseries{
+					name:       "http_got_expected_response",
+					metricType: metrics.Gauge,
+					tags:       ts.tags,
+				}
+				ms.store[responseTS] = value{newValue, 1}
+				log.Tracef("Created %q from %q", responseTS.name, ts.name)
+			}()
+
+			func() {
+				strCode, _ := ts.tags.Get("error_code")
+				newValue, _ := strconv.ParseFloat(strCode, 32)
+				errorCodeTS := timeseries{
+					name:       "http_error_code",
+					metricType: metrics.Gauge,
+					tags:       ts.tags,
+				}
+				ms.store[errorCodeTS] = value{newValue, 1}
+				log.Tracef("Created %q from %q", errorCodeTS.name, ts.name)
+			}()
+
+		// Rename to http_requests_failed_total
+		case "http_req_failed":
+			newTS := ts
+			newTS.name = "http_requests_failed_total"
+			ms.store[newTS] = v
+			log.Tracef("Created %q from %q", newTS.name, ts.name)
+
+		// Add _bytes suffix to data_sent and data_received.
+		case "data_sent", "data_received":
+			wihtSuffixTS := ts
+			wihtSuffixTS.name = wihtSuffixTS.name + "_bytes"
+			ms.store[wihtSuffixTS] = v
+			log.Tracef("Created %q from %q", wihtSuffixTS.name, ts.name)
+
+		// Tweak name and units.
+		case "http_req_duration":
+			newTS := ts
+			newTS.name = "http_total_duration_seconds"
+			v.value /= 1000 // convert from ms.
+			ms.store[newTS] = v
+			log.Tracef("Created %q from %q", newTS.name, ts.name)
+		case "iteration_duration":
+			newTS := ts
+			newTS.name = "iteration_duration_seconds"
+			v.value /= 1000 // convert from ms.
+			ms.store[newTS] = v
+			log.Tracef("Created %q from %q", newTS.name, ts.name)
+
+		// Squash multiple duration metrics into one with a "phase" label.
+		case "http_req_blocked", "http_req_connecting", "http_req_receiving", "http_req_sending", "http_req_tls_handshaking", "http_req_waiting":
+			newTS := ts
+			newTS.name = "http_duration_seconds"
+			phase := strings.TrimPrefix(ts.name, "http_req_")
+			newTS.tags = newTS.tags.With("phase", phase)
+			v.value /= 1000 // convert from ms.
+			ms.store[newTS] = v
+			log.Tracef("Created %s{phase=%q} from %q", newTS.name, phase, ts.name)
+
+		// Split checks metric into two: check_rate and check_total.
+		// TODO: We used to remove the "check" label due to it being high cardinality. However, we are reporting
+		// metrics for URLs which are also high cardinality, so it does not make a lot of sense to remove one but not
+		// others. For now, we're keeping the check metric.
+		case "checks":
+			func() {
+				newTS := ts
+				newTS.name = "check_success_rate"
+				ms.store[newTS] = v
+				log.Tracef("Created %q from %q", newTS.name, ts.name)
+			}()
+
+			// Create counters for the times a check failed and succeeded.
+			// This is done by multiplying success rate by # of samples and rounding.
+			func() {
+				newTS := ts
+				newTS.name = "checks_total"
+				newTS.tags = newTS.tags.With("result", "pass")
+				ms.store[newTS] = value{value: math.Round(v.value * float64(v.seenSamples)), seenSamples: 1}
+				log.Tracef("Created %q from %q", newTS.name, ts.name)
+			}()
+			func() {
+				newTS := ts
+				newTS.name = "checks_total"
+				newTS.tags = newTS.tags.With("result", "fail")
+				ms.store[newTS] = value{value: math.Round((1 - v.value) * float64(v.seenSamples)), seenSamples: 1}
+				log.Tracef("Created %q from %q", newTS.name, ts.name)
+			}()
+		}
+	}
+}
+
+// DeriveLogs produces logs from metrics.
+func (ms *metricStore) DeriveLogs(logger logrus.FieldLogger) {
+	for ts, v := range ms.store {
+		switch ts.name {
+		// Checks contains the number of checks performed and the rate of them that succeeded.
+		case "checks":
+			tags := ts.tags.Map()
+			if tags["group"] == "" {
+				// Be consistent with metrics, and ignore "group" tag if empty.
+				delete(tags, "group")
+			}
+
+			checkLogger := logger
+			for k, v := range tags {
+				checkLogger = checkLogger.WithField(k, v)
+			}
+			checkLogger.
+				WithField("value", v.value).
+				WithField("count", v.seenSamples).
+				WithField("metric", "checks_total").
+				Info("check result")
+		}
+	}
+}
+
+// RemoveLabels returns a new metricStore after removing labels not interesting for SM from all, or some metrics in the
+// store.
+func (ms *metricStore) RemoveLabels() {
+	log := ms.logger.WithField("step", "removeLabels")
+
+	// When we remove labels, we create a new TS without the label and store it on the map. As the new TS would have the
+	// same name, we cannot store it on the same map we're iterating over, or we could risk iterating over the newly
+	// added key. We need to duplicate the map for this.
+	newStore := make(map[timeseries]value, len(ms.store))
+
+	for ts, v := range ms.store {
+		if ts.name != "http_info" {
+			// We derived this metric earlier. Now we remove these tags from every other.
+			log.Tracef("Removing http info labels from %q", ts.name)
+			ts.tags = ts.tags.Without("tls_version")
+			ts.tags = ts.tags.Without("proto")
+		}
+
+		if ts.name != "http_status_code" {
+			// Moved to a dedicated metric.
+			log.Tracef("Removing status label from %q", ts.name)
+			ts.tags = ts.tags.Without("status")
+		}
+
+		// The documentation at https://k6.io/docs/using-k6/tags-and-groups/ seems to suggest that
+		// "group" should not be empty (it shouldn't be there if there's a single group), but I keep
+		// seeing instances of an empty group name.
+		if group, found := ts.tags.Get("group"); found && group == "" {
+			log.Tracef("Removing empty group label from %q", ts.name)
+			ts.tags = ts.tags.Without("group")
+		}
+
+		// Moved to dedicated metrics as values instead of tags.
+		ts.tags = ts.tags.Without("error_code")
+		ts.tags = ts.tags.Without("expected_response")
+
+		newStore[ts] = v
+	}
+
+	ms.store = newStore
+}
+
+// RemoveMetrics removes metrics that are not interesting in SM context.
+func (ms *metricStore) RemoveMetrics() {
+	log := ms.logger.WithField("step", "removeMetrics")
+
+	// As per BenchmarkRemove, it is better to store needles on a map. Experimentally, 8 needles or less are faster to
+	// store and check against in a slice, but 16 or more are faster on a map. Slices likely stop being worth it when
+	// the full slice does not fit on a cache line.
+	deletable := map[string]bool{
+		// Not useful in SM context:
+		"vus":     true,
+		"vus_max": true,
+		// Replaced by version with _bytes suffix:
+		"data_sent":     true,
+		"data_received": true,
+		// Renamed to _seconds.
+		"http_req_duration":  true,
+		"iteration_duration": true,
+		// Squashed into a single metric with a phase label.
+		"http_req_blocked": true, "http_req_connecting": true, "http_req_receiving": true, "http_req_sending": true, "http_req_tls_handshaking": true, "http_req_waiting": true,
+		// Renamed to http_requests(_failed)_total.
+		"http_reqs":       true,
+		"http_req_failed": true,
+		// Replaced by check_rate and checks_total
+		"checks": true,
+	}
+
+	for ts := range ms.store {
+		if deletable[ts.name] {
+			delete(ms.store, ts)
+			log.Tracef("Dropping %q", ts.name)
+		}
+	}
+}
+
 // Output is a k6 output plugin that writes metrics to an io.Writer in
 // Prometheus text exposition format.
 type Output struct {
 	logger logrus.FieldLogger
-	buffer output.SampleBuffer
+	store  *metricStore
 	out    io.WriteCloser
 	start  time.Time
 }
@@ -46,7 +415,16 @@ func New(p output.Params) (output.Output, error) {
 		return nil, err
 	}
 
-	return &Output{logger: p.Logger, out: fh}, nil
+	logger := p.Logger.WithField("output", "sm")
+
+	store := newMetricStore(32) // Reasonable size assumption.
+	store.logger = logger.WithField("component", "store")
+
+	return &Output{
+		logger: logger,
+		out:    fh,
+		store:  store,
+	}, nil
 }
 
 // Description returns a human-readable description of the output that will be
@@ -65,16 +443,25 @@ func (o *Output) Start() error {
 		"output": o.Description(),
 		"ts":     o.start.UnixMilli(),
 	}).Debug("starting output")
+
 	return nil
 }
 
 // AddMetricSamples receives the latest metric samples from the Engine.
-//
+// k6 docs say:
 // This method is called synchronously, so do not do anything blocking here
 // that might take a long time. Preferably, just use the SampleBuffer or
 // something like it to buffer metrics until they are flushed.
-func (o *Output) AddMetricSamples(samples []metrics.SampleContainer) {
-	o.buffer.AddMetricSamples(samples)
+//
+// Instead of using a SampleBuffer we, record samples in our metricStore directly. We estimate this is just as fast as
+// SampleBuffer, which also has a lock, while using less memory as we aggregate as we go instead of storing all samples
+// in memory.
+func (o *Output) AddMetricSamples(containers []metrics.SampleContainer) {
+	for _, samples := range containers {
+		for _, sample := range samples.GetSamples() {
+			o.store.Record(sample)
+		}
+	}
 }
 
 // Stop flushes all remaining metrics and finalize the test run.
@@ -87,661 +474,46 @@ func (o *Output) Stop() error {
 
 	defer o.out.Close()
 
-	genericMetrics := newGenericMetricsCollection()
-	targetMetrics := newTargetMetricsCollection()
+	o.store.Record(metrics.Sample{
+		TimeSeries: metrics.TimeSeries{
+			Metric: &metrics.Metric{
+				Name: "script_duration_seconds",
+				Type: metrics.Gauge,
+			},
+			Tags: (*metrics.TagSet)(atlas.New()),
+		},
+		Value: float64(duration.Milliseconds()),
+	})
 
-	genericMetrics.Update("script_duration_seconds", "Returns how long the script took to complete in seconds", "", "", duration.Seconds(), nil)
+	o.store.DeriveMetrics()
+	o.store.DeriveLogs(o.logger)
+	o.store.RemoveMetrics()
+	o.store.RemoveLabels()
 
-	for _, samples := range o.buffer.GetBufferedSamples() {
-		for _, sample := range samples.GetSamples() {
-			tags := getTags(sample)
-
-			scenario := tags["scenario"]
-			group := tags["group"]
-
-			if _, found := tags["name"]; found {
-				targetMetrics.Update(sample, scenario, group, tags)
-				continue
-			}
-
-			// The samples that don't have "name" in their tags seem to be generic metrics about various
-			// things.
-			//
-			// Seen so far:
-			//
-			// * checks -- this seems to be the number of checks performed (the number of times the check
-			//   function is called?) and the "check" tag might be different each time? But it seems to emit
-			//   one instance of "check" each time the function is called, even if it's with the same
-			//   "check" tag.
-			// * data_received -- this is the total for all requests in the scenario
-			// * data_sent -- this is the total for all requests in the scenario
-			// * iteration_duration -- the duration for the iteration in ms; with scenarios there seems to
-			//   be one iteration per scenario.
-			// * iterations -- not interesting, how many iterations in each scenario
-
-			metricName, value := deriveMetricNameAndValue(sample)
-			switch metricName {
-			case "":
-				continue
-
-			case "checks_total":
-				// "checks" is a little weird. It seems to be the number of checks performed
-				// (the number of times the check function is called?) and the "check" tag might
-				// be different each time becuase it's the name of the check provided as an
-				// argument to the check function. One of these samples seems to be emitted each
-				// time the check function is called.
-				//
-				// The tag describing the check is called "check", so we end up with a metric
-				// "check" with a label "check".
-				//
-				// The problem with this is that the check name seems to be free-form, so we
-				// might end up with invalid label values. This is probably a job for Loki,
-				// meaning we need an structured way of storing this information in logs.
-				fields := logrus.Fields{
-					"source":   ExtensionName,
-					"metric":   metricName,
-					"scenario": scenario,
-					"value":    value,
-				}
-				if group != "" {
-					fields["group"] = group
-				}
-				for k, v := range tags {
-					fields[k] = v
-				}
-				entry := o.logger.WithFields(fields)
-				entry.Info("check result")
-
-				delete(tags, "check")
-
-				// Now we need to do something weird: because the _value_ of the check metric is 0 if
-				// the check fails. If that's the case, add a tag result="fail" and set the value to 1
-				// (so that the metric is counting failures), otherwise add result="pass".
-				if value == 0 {
-					tags["result"] = "fail"
-					value = 1
-				} else {
-					tags["result"] = "pass"
-				}
-			}
-
-			genericMetrics.Update(metricName, "", scenario, group, value, tags)
-		}
+	for ts, value := range o.store.store {
+		fmt.Fprintf(o.out, "probe_%s%s %f\n", sanitizeLabelName(ts.name), marshalPrometheus(ts.tags.Map()), value.value)
 	}
-
-	// It might be a good idea to remove the tags from each of the metrics and instead create an scenario_info
-	// metric. The problem with this is that 1) there might be no scenario (in which case it might be named
-	// default?); 2) it's technically possible to add tags to invidual requests via request options.
-
-	genericMetrics.Write(o.out)
-
-	targetMetrics.Write(o.out)
 
 	return nil
 }
 
-func getTags(sample metrics.Sample) map[string]string {
-	var tags map[string]string
-	if sample.Tags != nil {
-		tags = sample.Tags.Map()
+func marshalPrometheus(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
 	}
 
-	// The documentation at https://k6.io/docs/using-k6/tags-and-groups/ seems to suggest that
-	// "group" should not be empty (it shouldn't be there if there's a single group), but I keep
-	// seeing instances of an empty group name.
-	if group, found := tags["group"]; found && group == "" {
-		delete(tags, "group")
+	labelNames := make([]string, 0, len(labels))
+	for k := range labels {
+		labelNames = append(labelNames, k)
+	}
+	slices.Sort(labelNames)
+
+	pairs := make([]string, 0, len(labelNames))
+	for _, name := range labelNames {
+		pairs = append(pairs, fmt.Sprintf("%s=%q", sanitizeLabelName(name), labels[name]))
 	}
 
-	return tags
-}
-
-func deriveMetricNameAndValue(sample metrics.Sample) (string, float64) {
-	metricName := sample.TimeSeries.Metric.Name
-	value := sample.Value
-
-	switch metricName {
-	case "iterations":
-		metricName = ""
-		value = 0
-
-	case "checks":
-		metricName = "checks_total"
-
-	case "iteration_duration":
-		metricName = "iteration_duration_seconds"
-		value /= 1000
-
-	case "data_sent":
-		metricName = "data_sent_bytes"
-
-	case "data_received":
-		metricName = "data_received_bytes"
-	}
-
-	return metricName, value
-}
-
-type targetId struct {
-	url      string
-	method   string
-	scenario string
-	group    string
-	name     string
-}
-
-type targetMetrics struct {
-	requests         int
-	failed           int
-	expectedResponse bool
-	group            string
-	scenario         string
-
-	// HTTP info
-	proto      string
-	tlsVersion string
-	status     []string
-
-	// timings
-	duration       []float64
-	blocked        []float64
-	connecting     []float64
-	sending        []float64
-	waiting        []float64
-	receiving      []float64
-	tlsHandshaking []float64
-
-	tags map[string]string
-}
-
-type targetMetricsCollection map[targetId]targetMetrics
-
-func newTargetMetricsCollection() targetMetricsCollection {
-	return make(targetMetricsCollection)
-}
-
-func (collection targetMetricsCollection) Update(sample metrics.Sample, scenario, group string, tags map[string]string) {
-	key := targetId{
-		url:      getURL(tags),
-		method:   tags["method"],
-		scenario: scenario,
-		group:    group,
-		name:     tags["name"],
-	}
-
-	// the metrics for this target
-	tm := collection[key]
-
-	tm.scenario = scenario
-	tm.group = group
-
-	switch sample.TimeSeries.Metric.Name {
-	case "http_reqs":
-		tm.requests += int(sample.Value)
-		tm.proto = tags["proto"]
-		tm.tlsVersion = tags["tls_version"]
-		tm.status = append(tm.status, tags["status"])
-	case "http_req_duration":
-		tm.duration = append(tm.duration, sample.Value/1000) // ms
-	case "http_req_blocked":
-		tm.blocked = append(tm.blocked, sample.Value/1000) // ms
-	case "http_req_connecting":
-		tm.connecting = append(tm.connecting, sample.Value/1000) // ms
-	case "http_req_tls_handshaking":
-		tm.tlsHandshaking = append(tm.tlsHandshaking, sample.Value/1000) // ms
-	case "http_req_sending":
-		tm.sending = append(tm.sending, sample.Value/1000) // ms
-	case "http_req_waiting":
-		tm.waiting = append(tm.waiting, sample.Value/1000) // ms
-	case "http_req_receiving":
-		tm.receiving = append(tm.receiving, sample.Value/1000) // ms
-	case "http_req_failed":
-		tm.failed += int(sample.Value)
-	}
-
-	// Remove elements from tags because the following are stored in dedicated fields.
-
-	delete(tags, "url")
-	delete(tags, RawURLTagName)
-	delete(tags, "method")
-	delete(tags, "scenario")
-	delete(tags, "group")
-	delete(tags, "name")
-
-	delete(tags, "proto")
-	delete(tags, "tls_version")
-	delete(tags, "status")
-
-	tm.tags = tags
-
-	collection[key] = tm
-}
-
-func (c targetMetricsCollection) Write(w io.Writer) {
-	for key, ti := range c {
-		out := newBufferedMetricTextOutput(w, "url", key.url, "method", key.method)
-		if key.scenario != "" {
-			out.Tags("scenario", key.scenario)
-		}
-		if key.group != "" {
-			out.Tags("group", key.group)
-		}
-		if key.name != "" {
-			out.Tags("name", key.name)
-		}
-
-		// Remove expected_reponse from tags and write it as a separate
-		// metric. It reads weirdly as a label, specially one that is
-		// applied to all the metrics.
-		expectedResponse := ti.tags["expected_response"]
-		delete(ti.tags, "expected_response")
-
-		out.Name("probe_http_got_expected_response")
-		if expectedResponse == "false" {
-			out.Value(0)
-		} else {
-			out.Value(1)
-		}
-
-		// Remove error code from tags and write it as a separate
-		// metric because the possible values span ~ 700 values.
-		errorCode := ti.tags["error_code"]
-		delete(ti.tags, "error_code")
-
-		out.Name("probe_http_error_code")
-		if errorCode == "" || errorCode == "0" {
-			out.Value(0)
-		} else if v, err := strconv.Atoi(errorCode); err != nil {
-			out.Value(-1)
-		} else {
-			out.Value(v)
-		}
-
-		out.Name("probe_http_info")
-		if ti.tlsVersion != "" {
-			out.KeyValue(`tls_version`, strings.TrimPrefix(ti.tlsVersion, "tls"))
-		}
-		// If the request failed, proto might be empty because there
-		// was no response.
-		if len(ti.proto) > 0 {
-			out.KeyValue("proto", ti.proto)
-		}
-
-		for k, v := range ti.tags {
-			out.KeyValue(k, v)
-		}
-		out.Value(1)
-
-		out.Name("probe_http_requests_total")
-		out.Value(ti.requests)
-
-		out.Name("probe_http_requests_failed_total")
-		out.Value(ti.failed)
-
-		// TODO(mem): decide what to do with failed requests.
-		//
-		// If a request fails, depending on the reason, some of the
-		// timings might be missing. This means that we might skew the
-		// results towards 0 if we try to do over-time aggregations.
-
-		out.Name(`probe_http_status_code`)
-		out.Value(ti.status[0])
-
-		if protoVersion := strings.TrimPrefix(strings.ToLower(ti.proto), "http/"); len(protoVersion) > 0 {
-			out.Name(`probe_http_version`)
-			out.Value(protoVersion) // XXX
-		}
-
-		out.Name(`probe_http_ssl`)
-		if ti.tlsVersion == "" {
-			out.Value(0)
-		} else {
-			out.Value(1)
-		}
-
-		if ti.requests == 1 {
-			out.Name("probe_http_duration_seconds")
-			out.KeyValue("phase", "resolve")
-			out.Value(0)
-
-			out.Name("probe_http_duration_seconds")
-			out.KeyValue("phase", "connect")
-			out.Value(ti.connecting[0])
-
-			out.Name("probe_http_duration_seconds")
-			out.KeyValue("phase", "tls")
-			out.Value(ti.tlsHandshaking[0])
-
-			out.Name("probe_http_duration_seconds")
-			out.KeyValue("phase", "processing")
-			out.Value(ti.waiting[0])
-
-			out.Name("probe_http_duration_seconds")
-			out.KeyValue("phase", "transfer")
-			out.Value(ti.receiving[0])
-
-			out.Name("probe_http_total_duration_seconds")
-			out.Value(ti.duration[0])
-
-			// ti.sending: writing the request
-			// ti.blocked: waiting for the connection to be available
-		} else {
-			out.Name("probe_http_duration_seconds")
-			out.KeyValue("phase", "resolve")
-			out.Stats(make([]float64, ti.requests))
-
-			out.Name("probe_http_duration_seconds")
-			out.KeyValue("phase", "connect")
-			out.Stats(ti.connecting)
-
-			out.Name("probe_http_duration_seconds")
-			out.KeyValue("phase", "tls")
-			out.Stats(ti.tlsHandshaking)
-
-			out.Name("probe_http_duration_seconds")
-			out.KeyValue("phase", "processing")
-			out.Stats(ti.waiting)
-
-			out.Name("probe_http_duration_seconds")
-			out.KeyValue("phase", "transfer")
-			out.Stats(ti.receiving)
-
-			out.Name("probe_http_total_duration_seconds")
-			out.Stats(ti.duration)
-		}
-	}
-}
-
-type genericMetric struct {
-	name  string
-	value float64
-	tags  map[string]string
-	help  string
-}
-
-type genericMetricsCollection map[string]genericMetric
-
-func newGenericMetricsCollection() genericMetricsCollection {
-	return make(genericMetricsCollection)
-}
-
-func (c genericMetricsCollection) Update(metric, help, scenario, group string, delta float64, tags map[string]string) {
-	var key strings.Builder
-
-	key.WriteString(metric)
-	key.WriteString(scenario)
-	key.WriteString(group)
-
-	keys := make([]string, 0, len(tags))
-	for k := range tags {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		key.WriteString(k)
-		key.WriteString(tags[k])
-	}
-
-	keyStr := key.String()
-
-	m := c[keyStr]
-	m.name = metric
-	m.help = help
-	m.value += delta
-	if len(tags) > 0 {
-		m.tags = tags
-	}
-	c[keyStr] = m
-}
-
-func (c genericMetricsCollection) Write(w io.Writer) {
-	for _, metric := range c {
-		out := newBufferedMetricTextOutput(w)
-		out.Name("probe_" + metric.name)
-		out.Help(metric.help)
-		for key, value := range metric.tags {
-			out.Tags(key, value)
-		}
-		// output stats instead?
-		out.Value(metric.value)
-	}
-}
-
-type immediateMetricTextOutput struct {
-	dest                io.Writer
-	commonKeysAndValues []string
-	count               int
-}
-
-func newMetricTextOutput(dest io.Writer, keysAndValues ...string) *immediateMetricTextOutput {
-	return &immediateMetricTextOutput{dest: dest, commonKeysAndValues: keysAndValues}
-}
-
-func (o *immediateMetricTextOutput) Name(name string) {
-	fmt.Fprint(o.dest, name)
-	fmt.Fprint(o.dest, "{")
-	o.count = 0
-}
-
-func (o *immediateMetricTextOutput) KeyValue(key, value string) {
-	if o.count > 0 {
-		fmt.Fprint(o.dest, ",")
-	}
-
-	if !isValidMetricName(key) {
-		key = sanitizeLabelName(key)
-	}
-
-	fmt.Fprint(o.dest, key)
-	fmt.Fprint(o.dest, `="`)
-	fmt.Fprint(o.dest, value)
-	fmt.Fprint(o.dest, `"`)
-
-	o.count++
-}
-
-func (o *immediateMetricTextOutput) Value(v any) {
-	for i := 0; i < len(o.commonKeysAndValues); i += 2 {
-		key := o.commonKeysAndValues[i]
-		if !isValidMetricName(key) {
-			key = sanitizeLabelName(key)
-		}
-		o.KeyValue(key, o.commonKeysAndValues[i+1])
-	}
-	fmt.Fprint(o.dest, "} ")
-	fmt.Fprintln(o.dest, v)
-}
-
-type bufferedMetricTextOutput struct {
-	dest                io.Writer
-	commonKeysAndValues []string
-	name                string
-	help                string
-	buf                 strings.Builder
-}
-
-func newBufferedMetricTextOutput(dest io.Writer, keysAndValues ...string) *bufferedMetricTextOutput {
-	return &bufferedMetricTextOutput{dest: dest, commonKeysAndValues: keysAndValues}
-}
-
-func (o *bufferedMetricTextOutput) Name(name string) {
-	o.name = name
-	o.buf.Reset()
-}
-
-func (o *bufferedMetricTextOutput) Help(str string) {
-	o.help = str
-}
-
-func (o *bufferedMetricTextOutput) Tags(keysAndValues ...string) {
-	o.commonKeysAndValues = append(o.commonKeysAndValues, keysAndValues...)
-}
-
-func (o *bufferedMetricTextOutput) KeyValue(key, value string) {
-	if o.buf.Len() > 0 {
-		o.buf.WriteRune(',')
-	}
-
-	if !isValidMetricName(key) {
-		key = sanitizeLabelName(key)
-	}
-
-	o.buf.WriteString(key)
-	o.buf.WriteRune('=')
-	o.buf.WriteRune('"')
-	o.buf.WriteString(value)
-	o.buf.WriteRune('"')
-}
-
-func (o *bufferedMetricTextOutput) Value(v any) {
-	for i := 0; i < len(o.commonKeysAndValues); i += 2 {
-		if o.buf.Len() > 0 {
-			o.buf.WriteRune(',')
-		}
-
-		key := o.commonKeysAndValues[i]
-		if !isValidMetricName(key) {
-			key = sanitizeLabelName(key)
-		}
-
-		o.buf.WriteString(key)
-		o.buf.WriteRune('=')
-		o.buf.WriteRune('"')
-		o.buf.WriteString(o.commonKeysAndValues[i+1])
-		o.buf.WriteRune('"')
-	}
-
-	if o.help != "" {
-		fmt.Fprintf(o.dest, "# HELP %s %s\n", o.name, o.help)
-	}
-
-	fmt.Fprint(o.dest, o.name)
-	fmt.Fprint(o.dest, "{")
-	fmt.Fprint(o.dest, o.buf.String())
-	fmt.Fprint(o.dest, "} ")
-	fmt.Fprintln(o.dest, v)
-}
-
-func (o *bufferedMetricTextOutput) Stats(v []float64) {
-	for i := 0; i < len(o.commonKeysAndValues); i += 2 {
-		if o.buf.Len() > 0 {
-			o.buf.WriteRune(',')
-		}
-
-		key := o.commonKeysAndValues[i]
-		if !isValidMetricName(key) {
-			key = sanitizeLabelName(key)
-		}
-
-		o.buf.WriteString(key)
-		o.buf.WriteRune('=')
-		o.buf.WriteRune('"')
-		o.buf.WriteString(o.commonKeysAndValues[i+1])
-		o.buf.WriteRune('"')
-	}
-
-	stats := getStats(v)
-
-	fmt.Fprint(o.dest, o.name)
-	fmt.Fprint(o.dest, "_min")
-	fmt.Fprint(o.dest, "{")
-	fmt.Fprint(o.dest, o.buf.String())
-	fmt.Fprint(o.dest, "} ")
-	fmt.Fprintln(o.dest, stats.min)
-
-	fmt.Fprint(o.dest, o.name)
-	fmt.Fprint(o.dest, "_max")
-	fmt.Fprint(o.dest, "{")
-	fmt.Fprint(o.dest, o.buf.String())
-	fmt.Fprint(o.dest, "} ")
-	fmt.Fprintln(o.dest, stats.max)
-
-	fmt.Fprint(o.dest, o.name)
-	// fmt.Fprint(o.dest, "_mean")
-	fmt.Fprint(o.dest, "{")
-	fmt.Fprint(o.dest, o.buf.String())
-	fmt.Fprint(o.dest, "} ")
-	fmt.Fprintln(o.dest, stats.med)
-
-	fmt.Fprint(o.dest, o.name)
-	fmt.Fprint(o.dest, "_count")
-	fmt.Fprint(o.dest, "{")
-	fmt.Fprint(o.dest, o.buf.String())
-	fmt.Fprint(o.dest, "} ")
-	fmt.Fprintln(o.dest, stats.n)
-
-	fmt.Fprint(o.dest, o.name)
-	fmt.Fprint(o.dest, "_sum")
-	fmt.Fprint(o.dest, "{")
-	fmt.Fprint(o.dest, o.buf.String())
-	fmt.Fprint(o.dest, "} ")
-	fmt.Fprintln(o.dest, stats.sum)
-}
-
-type stats struct {
-	n   int
-	min float64
-	max float64
-	med float64
-	sum float64
-}
-
-func getStats(a []float64) stats {
-	sort.Float64s(a)
-
-	out := stats{
-		n:   len(a),
-		min: a[0],
-		max: a[len(a)-1],
-	}
-
-	for _, v := range a {
-		out.sum += v
-	}
-
-	if out.n > 1 {
-		p, f := modf(float64(out.n-1) * 0.5)
-		out.med = lerp(a[p], a[p+1], f)
-	} else {
-		out.med = out.min
-	}
-
-	return out
-}
-
-// lerp returns the linear interpolation between a and b at t.
-func lerp(a, b, t float64) float64 {
-	return (1-t)*a + t*b
-}
-
-// modf returns the integer and fractional parts of n.
-func modf(n float64) (int, float64) {
-	i, f := math.Modf(n)
-	return int(i), f
-}
-
-var validMetricNameRe = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
-
-// isValidMetricNameRe returns true iff s is a valid metric name.
-func isValidMetricNameRe(s string) bool {
-	return validMetricNameRe.MatchString(s)
-}
-
-// isValidMetricName returns true iff s is a valid metric name.
-//
-// This function is a faster hardcoded implementation wrt to the regular expression.
-func isValidMetricName(s string) bool {
-	if len(s) == 0 {
-		return false
-	}
-
-	for i, r := range s {
-		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' || r == ':' || (r >= '0' && r <= '9' && i > 0)) {
-			return false
-		}
-	}
-
-	return true
+	return "{" + strings.Join(pairs, ",") + "}"
 }
 
 // sanitizeLabelName replaces all invalid characters in s with '_'.
@@ -757,12 +529,4 @@ func sanitizeLabelName(s string) string {
 	}
 
 	return builder.String()
-}
-
-func getURL(m map[string]string) string {
-	if u := m[RawURLTagName]; u != "" {
-		return u
-	}
-
-	return m["url"]
 }

--- a/output.go
+++ b/output.go
@@ -385,13 +385,6 @@ func (ms *metricStore) RemoveLabels() {
 	newStore := make(map[timeseries]value, len(ms.store))
 
 	for ts, v := range ms.store {
-		if ts.name != "http_info" {
-			// We derived this metric earlier. Now we remove these tags from every other.
-			log.Tracef("Removing http info labels from %q", ts.name)
-			ts.tags = ts.tags.Without("tls_version")
-			ts.tags = ts.tags.Without("proto")
-		}
-
 		// The documentation at https://k6.io/docs/using-k6/tags-and-groups/ seems to suggest that
 		// "group" should not be empty (it shouldn't be there if there's a single group), but I keep
 		// seeing instances of an empty group name.

--- a/output.go
+++ b/output.go
@@ -538,7 +538,7 @@ func (o *Output) Stop() error {
 			},
 			Tags: (*metrics.TagSet)(atlas.New()),
 		},
-		Value: float64(duration.Milliseconds()),
+		Value: float64(duration.Seconds()),
 	})
 
 	o.store.DeriveMetrics()

--- a/output.go
+++ b/output.go
@@ -350,8 +350,8 @@ func (ms *metricStore) RemoveLabels() {
 			ts.tags = ts.tags.Without("proto")
 		}
 
-		if ts.name != "http_status_code" {
-			// Moved to a dedicated metric.
+		if ts.name != "http_requests_total" {
+			// Keep status label only on total requests.
 			log.Tracef("Removing status label from %q", ts.name)
 			ts.tags = ts.tags.Without("status")
 		}

--- a/output.go
+++ b/output.go
@@ -172,10 +172,14 @@ func (ms *metricStore) DeriveMetrics() {
 			}()
 
 			func() {
+				tags := ts.tags
+				if tlsVersion, found := ts.tags.Get("tls_version"); found {
+					tags = ts.tags.Without("tls_version").With("tls_version", strings.TrimPrefix(tlsVersion, "tls"))
+				}
 				infoTS := timeseries{
 					name:       "http_info",
 					metricType: metrics.Gauge,
-					tags:       ts.tags,
+					tags:       tags,
 				}
 				ms.store[infoTS] = value{1, 1}
 				log.Tracef("Created %q from %q", infoTS.name, ts.name)

--- a/output_test.go
+++ b/output_test.go
@@ -1,13 +1,12 @@
 package sm
 
 import (
-	"bytes"
 	"io"
-	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/metrics"
 	"go.k6.io/k6/output"
@@ -21,15 +20,15 @@ func TestOutputNew(t *testing.T) {
 		expectError bool
 	}{
 		"happy path": {
-			input:       output.Params{ConfigArgument: "test.out", FS: afero.NewMemMapFs()},
+			input:       output.Params{ConfigArgument: "test.out", FS: afero.NewMemMapFs(), Logger: nopLogger()},
 			expectError: false,
 		},
 		"no filename": {
-			input:       output.Params{ConfigArgument: "", FS: afero.NewMemMapFs()},
+			input:       output.Params{ConfigArgument: "", FS: afero.NewMemMapFs(), Logger: nopLogger()},
 			expectError: true,
 		},
 		"cannot create file": {
-			input:       output.Params{ConfigArgument: "test.out", FS: afero.NewReadOnlyFs(afero.NewMemMapFs())},
+			input:       output.Params{ConfigArgument: "test.out", FS: afero.NewReadOnlyFs(afero.NewMemMapFs()), Logger: nopLogger()},
 			expectError: true,
 		},
 	}
@@ -78,158 +77,87 @@ func TestOutputStartStop(t *testing.T) {
 	require.Contains(t, string(output), "probe_script_duration_seconds")
 }
 
-func makeSample(name string, value float64) metrics.Sample {
-	return metrics.Sample{
-		TimeSeries: metrics.TimeSeries{
+// TestMetricStore tests the metricStore functionality that is hard to test from an integration perspective.
+func TestMetricStore(t *testing.T) {
+	t.Parallel()
+
+	t.Run("aggregation", func(t *testing.T) {
+		t.Parallel()
+
+		store := newMetricStore(8)
+
+		trendA := metrics.TimeSeries{
 			Metric: &metrics.Metric{
-				Name: name,
+				Name: "im_trend_a",
+				Type: metrics.Trend,
 			},
-		},
-		Value: value,
-	}
-}
+			Tags: nil,
+		}
+		trendB := metrics.TimeSeries{
+			Metric: &metrics.Metric{
+				Name: "im_trend_b",
+				Type: metrics.Trend,
+			},
+			Tags: nil,
+		}
 
-func TestDeriveMetricNameAndValue(t *testing.T) {
-	t.Parallel()
+		gaugeA := metrics.TimeSeries{
+			Metric: &metrics.Metric{
+				Name: "im_gauge_a",
+				Type: metrics.Gauge,
+			},
+			Tags: nil,
+		}
+		gaugeB := metrics.TimeSeries{
+			Metric: &metrics.Metric{
+				Name: "im_gaguge_b",
+				Type: metrics.Gauge,
+			},
+			Tags: nil,
+		}
 
-	testcases := map[string]struct {
-		input         metrics.Sample
-		expectedName  string
-		expectedValue float64
-	}{
-		"iterations": {
-			input:         makeSample("iterations", 1),
-			expectedName:  "",
-			expectedValue: 0,
-		},
-		"checks": {
-			input:         makeSample("checks", 1),
-			expectedName:  "checks_total",
-			expectedValue: 1,
-		},
-		"iteration_duration": {
-			input:         makeSample("iteration_duration", 1),
-			expectedName:  "iteration_duration_seconds",
-			expectedValue: 0.001,
-		},
-		"data_sent": {
-			input:         makeSample("data_sent", 1),
-			expectedName:  "data_sent_bytes",
-			expectedValue: 1,
-		},
-		"data_received": {
-			input:         makeSample("data_received", 1),
-			expectedName:  "data_received_bytes",
-			expectedValue: 1,
-		},
-		"something_else": {
-			input:         makeSample("something_else", 42),
-			expectedName:  "something_else",
-			expectedValue: 42,
-		},
-	}
+		counterA := metrics.TimeSeries{
+			Metric: &metrics.Metric{
+				Name: "im_counter_a",
+				Type: metrics.Counter,
+			},
+			Tags: nil,
+		}
+		counterB := metrics.TimeSeries{
+			Metric: &metrics.Metric{
+				Name: "im_counter_b",
+				Type: metrics.Counter,
+			},
+			Tags: nil,
+		}
 
-	for name, tc := range testcases {
-		tc := tc
+		store.Record(metrics.Sample{TimeSeries: trendA, Value: 1})
+		store.Record(metrics.Sample{TimeSeries: trendB, Value: 1})
+		store.Record(metrics.Sample{TimeSeries: trendA, Value: 2})
 
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
+		store.Record(metrics.Sample{TimeSeries: gaugeA, Value: 1})
+		store.Record(metrics.Sample{TimeSeries: gaugeB, Value: 1})
+		store.Record(metrics.Sample{TimeSeries: gaugeA, Value: 2})
 
-			actualName, actualValue := deriveMetricNameAndValue(tc.input)
-			require.Equal(t, tc.expectedName, actualName)
-			require.Equal(t, tc.expectedValue, actualValue)
-		})
-	}
-}
+		store.Record(metrics.Sample{TimeSeries: counterA, Value: 1})
+		store.Record(metrics.Sample{TimeSeries: counterB, Value: 1})
+		store.Record(metrics.Sample{TimeSeries: counterA, Value: 2})
 
-func TestGetStats(t *testing.T) {
-	t.Parallel()
+		assert.Equal(t, 1.5, store.store[timeseriesFromK6(trendA)].value)
+		assert.Equal(t, 2, store.store[timeseriesFromK6(trendA)].seenSamples)
+		assert.Equal(t, 1.0, store.store[timeseriesFromK6(trendB)].value)
+		assert.Equal(t, 1, store.store[timeseriesFromK6(trendB)].seenSamples)
 
-	testcases := map[string]struct {
-		input    []float64
-		expected stats
-	}{
-		"1": { // single sample
-			input:    []float64{1.0},
-			expected: stats{n: 1, min: 1, max: 1, sum: 1, med: 1},
-		},
-		"2": { // two samples
-			input:    []float64{1.0, 2.0},
-			expected: stats{n: 2, min: 1, max: 2, sum: 3, med: 1.5},
-		},
-		"3": { // three samples, regular
-			input:    []float64{1.0, 2.0, 3.0},
-			expected: stats{n: 3, min: 1, max: 3, sum: 6, med: 2.0},
-		},
-		"3b": { // three samples, irregular
-			input:    []float64{1.0, 2.0, 4.0},
-			expected: stats{n: 3, min: 1, max: 4, sum: 7, med: 2.0},
-		},
-		"4": { // four samples, irregular
-			input:    []float64{1.0, 2.0, 4.0, 5.0},
-			expected: stats{n: 4, min: 1, max: 5, sum: 12, med: 3.0},
-		},
-	}
+		assert.Equal(t, 2.0, store.store[timeseriesFromK6(gaugeA)].value)
+		assert.Equal(t, 2, store.store[timeseriesFromK6(gaugeA)].seenSamples)
+		assert.Equal(t, 1.0, store.store[timeseriesFromK6(gaugeB)].value)
+		assert.Equal(t, 1, store.store[timeseriesFromK6(gaugeB)].seenSamples)
 
-	for name, tc := range testcases {
-		tc := tc
-
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			actual := getStats(tc.input)
-			if tc.expected != actual {
-				t.Log("expected:", tc.expected, "actual:", actual)
-				t.Fail()
-			}
-		})
-	}
-}
-
-func TestIsValidMetricName(t *testing.T) {
-	t.Parallel()
-
-	testcases := map[string]struct {
-		input    string
-		expected bool
-	}{
-		"single letter":         {input: "a", expected: true},
-		"word":                  {input: "abc", expected: true},
-		"letter and number":     {input: "a1", expected: true},
-		"number":                {input: "1", expected: false},
-		"numbers":               {input: "123", expected: false},
-		"underscore":            {input: "_", expected: true},
-		"valid with underscore": {input: "a_b_c", expected: true},
-		"valid with numbers":    {input: "a_1_2", expected: true},
-		"colon":                 {input: ":", expected: true},
-		"namespace":             {input: "abc::xyz", expected: true},
-		"blank":                 {input: " ", expected: false},
-		"words with blank":      {input: "abc xyz", expected: false},
-		"dash":                  {input: "-", expected: false},
-		"words with dash":       {input: "abc-xyz", expected: false},
-		"utf8":                  {input: "á", expected: false},
-		"empty":                 {input: "", expected: false},
-	}
-
-	for name, tc := range testcases {
-		tc := tc
-
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			actual := isValidMetricNameRe(tc.input)
-			if actual != tc.expected {
-				t.Log("expected:", tc.expected, "actual:", actual, "input:", tc.input)
-				t.Fail()
-			}
-
-			actualNonRe := isValidMetricName(tc.input)
-			if actualNonRe != actual {
-				t.Log("expected:", actual, "actual:", actualNonRe, "input:", tc.input)
-				t.Fail()
-			}
-		})
-	}
+		assert.Equal(t, 3.0, store.store[timeseriesFromK6(counterA)].value)
+		assert.Equal(t, 2, store.store[timeseriesFromK6(counterA)].seenSamples)
+		assert.Equal(t, 1.0, store.store[timeseriesFromK6(counterB)].value)
+		assert.Equal(t, 1, store.store[timeseriesFromK6(counterB)].seenSamples)
+	})
 }
 
 func TestSanitizeLabelName(t *testing.T) {
@@ -265,385 +193,6 @@ func TestSanitizeLabelName(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestBufferedMetricTextOutputValue(t *testing.T) {
-	t.Parallel()
-
-	type metricData struct {
-		name  string
-		kvs   []string
-		value float64
-	}
-
-	testcases := map[string]struct {
-		kvs      []string
-		data     []metricData
-		expected string
-	}{
-		"basic": {
-			data: []metricData{
-				{
-					name:  "test",
-					value: 1,
-				},
-			},
-			expected: "test{} 1\n",
-		},
-		"one keyval": {
-			kvs: []string{"key", "value"},
-			data: []metricData{
-				{
-					name:  "test",
-					value: 1,
-				},
-			},
-			expected: "test{key=\"value\"} 1\n",
-		},
-		"multiple keyval": {
-			kvs: []string{"key1", "1", "key2", "2"},
-			data: []metricData{
-				{
-					name:  "test",
-					value: 1,
-				},
-			},
-			expected: "test{key1=\"1\",key2=\"2\"} 1\n",
-		},
-		"extra keyvals": {
-			kvs: []string{"key1", "1"},
-			data: []metricData{
-				{
-					name:  "test",
-					kvs:   []string{"key2", "2"},
-					value: 1,
-				},
-			},
-			expected: "test{key2=\"2\",key1=\"1\"} 1\n",
-		},
-		"invalid key": {
-			kvs: []string{"key 1", "1", "key 2", "2"},
-			data: []metricData{
-				{
-					name:  "test",
-					value: 1,
-				},
-			},
-			expected: "test{key_1=\"1\",key_2=\"2\"} 1\n",
-		},
-		"multiple metrics": {
-			kvs: []string{"key 1", "1", "key 2", "2"},
-			data: []metricData{
-				{
-					name:  "a",
-					value: 1,
-					kvs:   []string{"key3", "3"},
-				},
-				{
-					name:  "b",
-					value: 2,
-					kvs:   []string{"key4", "4"},
-				},
-			},
-			expected: "a{key3=\"3\",key_1=\"1\",key_2=\"2\"} 1\nb{key4=\"4\",key_1=\"1\",key_2=\"2\"} 2\n",
-		},
-	}
-
-	for name, tc := range testcases {
-		tc := tc
-
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			var buf bytes.Buffer
-			to := newBufferedMetricTextOutput(&buf, tc.kvs...)
-			for _, d := range tc.data {
-				to.Name(d.name)
-				for i := 0; i < len(d.kvs); i += 2 {
-					to.KeyValue(d.kvs[i], d.kvs[i+1])
-				}
-				to.Value(d.value)
-			}
-			require.Equal(t, tc.expected, buf.String())
-		})
-	}
-}
-
-func joinNewline(s ...string) string {
-	return strings.Join(s, "\n") + "\n"
-}
-
-func TestBufferedMetricTextOutputStats(t *testing.T) {
-	t.Parallel()
-
-	type metricData struct {
-		name   string
-		kvs    []string
-		values []float64
-	}
-
-	testcases := map[string]struct {
-		kvs      []string
-		data     []metricData
-		expected string
-	}{
-		"basic": {
-			data: []metricData{
-				{
-					name:   "test",
-					values: []float64{1},
-				},
-			},
-			expected: joinNewline(
-				`test_min{} 1`,
-				`test_max{} 1`,
-				`test{} 1`,
-				`test_count{} 1`,
-				`test_sum{} 1`,
-			),
-		},
-		"one keyval": {
-			kvs: []string{"key", "value"},
-			data: []metricData{
-				{
-					name:   "test",
-					values: []float64{1},
-				},
-			},
-			expected: joinNewline(
-				`test_min{key="value"} 1`,
-				`test_max{key="value"} 1`,
-				`test{key="value"} 1`,
-				`test_count{key="value"} 1`,
-				`test_sum{key="value"} 1`,
-			),
-		},
-		"multiple keyval": {
-			kvs: []string{"key1", "1", "key2", "2"},
-			data: []metricData{
-				{
-					name:   "test",
-					values: []float64{1},
-				},
-			},
-			expected: joinNewline(
-				`test_min{key1="1",key2="2"} 1`,
-				`test_max{key1="1",key2="2"} 1`,
-				`test{key1="1",key2="2"} 1`,
-				`test_count{key1="1",key2="2"} 1`,
-				`test_sum{key1="1",key2="2"} 1`,
-			),
-		},
-		"extra keyvals": {
-			kvs: []string{"key1", "1"},
-			data: []metricData{
-				{
-					name:   "test",
-					kvs:    []string{"key2", "2"},
-					values: []float64{1},
-				},
-			},
-			expected: joinNewline(
-				`test_min{key2="2",key1="1"} 1`,
-				`test_max{key2="2",key1="1"} 1`,
-				`test{key2="2",key1="1"} 1`,
-				`test_count{key2="2",key1="1"} 1`,
-				`test_sum{key2="2",key1="1"} 1`,
-			),
-		},
-		"invalid key": {
-			kvs: []string{"key 1", "1", "key 2", "2"},
-			data: []metricData{
-				{
-					name:   "test",
-					values: []float64{1},
-				},
-			},
-			expected: joinNewline(
-				`test_min{key_1="1",key_2="2"} 1`,
-				`test_max{key_1="1",key_2="2"} 1`,
-				`test{key_1="1",key_2="2"} 1`,
-				`test_count{key_1="1",key_2="2"} 1`,
-				`test_sum{key_1="1",key_2="2"} 1`,
-			),
-		},
-		"multiple metrics": {
-			kvs: []string{"key 1", "1", "key 2", "2"},
-			data: []metricData{
-				{
-					name:   "a",
-					values: []float64{1, 2, 3},
-					kvs:    []string{"key3", "3"},
-				},
-				{
-					name:   "b",
-					values: []float64{2, 4, 6},
-					kvs:    []string{"key 4", "4", "key5", "5"},
-				},
-			},
-			expected: joinNewline(
-				`a_min{key3="3",key_1="1",key_2="2"} 1`,
-				`a_max{key3="3",key_1="1",key_2="2"} 3`,
-				`a{key3="3",key_1="1",key_2="2"} 2`,
-				`a_count{key3="3",key_1="1",key_2="2"} 3`,
-				`a_sum{key3="3",key_1="1",key_2="2"} 6`,
-				`b_min{key_4="4",key5="5",key_1="1",key_2="2"} 2`,
-				`b_max{key_4="4",key5="5",key_1="1",key_2="2"} 6`,
-				`b{key_4="4",key5="5",key_1="1",key_2="2"} 4`,
-				`b_count{key_4="4",key5="5",key_1="1",key_2="2"} 3`,
-				`b_sum{key_4="4",key5="5",key_1="1",key_2="2"} 12`,
-			),
-		},
-	}
-
-	for name, tc := range testcases {
-		t.Run(name, func(t *testing.T) {
-			var buf bytes.Buffer
-			to := newBufferedMetricTextOutput(&buf, tc.kvs...)
-			for _, d := range tc.data {
-				to.Name(d.name)
-				for i := 0; i < len(d.kvs); i += 2 {
-					to.KeyValue(d.kvs[i], d.kvs[i+1])
-				}
-				to.Stats(d.values)
-			}
-			require.Equal(t, tc.expected, buf.String())
-		})
-	}
-}
-
-func TestTargetMetricsCollectionWriteOne(t *testing.T) {
-	t.Parallel()
-
-	c := newTargetMetricsCollection()
-
-	require.Len(t, c, 0)
-
-	c[targetId{
-		url:      "http://example.com",
-		method:   "GET",
-		scenario: "s",
-		group:    "g",
-	}] = targetMetrics{
-		requests:         1,
-		failed:           0,
-		expectedResponse: false,
-		scenario:         "s",
-		group:            "g",
-		proto:            "1.1",
-		tlsVersion:       "1.3",
-		status:           []string{"200"},
-		duration:         []float64{0.001},
-		blocked:          []float64{0.001},
-		connecting:       []float64{0.001},
-		sending:          []float64{0.001},
-		waiting:          []float64{0.001},
-		receiving:        []float64{0.001},
-		tlsHandshaking:   []float64{0.001},
-		tags:             map[string]string{"k": "v"},
-	}
-
-	var buf bytes.Buffer
-
-	c.Write(&buf)
-
-	expected := joinNewline(
-		`probe_http_got_expected_response{url="http://example.com",method="GET",scenario="s",group="g"} 1`,
-		`probe_http_error_code{url="http://example.com",method="GET",scenario="s",group="g"} 0`,
-		`probe_http_info{tls_version="1.3",proto="1.1",k="v",url="http://example.com",method="GET",scenario="s",group="g"} 1`,
-		`probe_http_requests_total{url="http://example.com",method="GET",scenario="s",group="g"} 1`,
-		`probe_http_requests_failed_total{url="http://example.com",method="GET",scenario="s",group="g"} 0`,
-		`probe_http_status_code{url="http://example.com",method="GET",scenario="s",group="g"} 200`,
-		`probe_http_version{url="http://example.com",method="GET",scenario="s",group="g"} 1.1`,
-		`probe_http_ssl{url="http://example.com",method="GET",scenario="s",group="g"} 1`,
-		`probe_http_duration_seconds{phase="resolve",url="http://example.com",method="GET",scenario="s",group="g"} 0`,
-		`probe_http_duration_seconds{phase="connect",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds{phase="tls",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds{phase="processing",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds{phase="transfer",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_total_duration_seconds{url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-	)
-
-	require.Equal(t, expected, buf.String())
-}
-
-func TestTargetMetricsCollectionWriteMany(t *testing.T) {
-	t.Parallel()
-
-	c := newTargetMetricsCollection()
-
-	require.Len(t, c, 0)
-
-	c[targetId{
-		url:      "http://example.com",
-		method:   "GET",
-		scenario: "s",
-		group:    "g",
-	}] = targetMetrics{
-		requests:         2,
-		failed:           1,
-		expectedResponse: false,
-		scenario:         "s",
-		group:            "g",
-		proto:            "1.1",
-		tlsVersion:       "1.3",
-		status:           []string{"200", "200"},
-		duration:         []float64{0.001, 0.001},
-		blocked:          []float64{0.001, 0.001},
-		connecting:       []float64{0.001, 0.001},
-		sending:          []float64{0.001, 0.001},
-		waiting:          []float64{0.001, 0.001},
-		receiving:        []float64{0.001, 0.001},
-		tlsHandshaking:   []float64{0.001, 0.001},
-		tags:             map[string]string{"k": "v"},
-	}
-
-	var buf bytes.Buffer
-
-	c.Write(&buf)
-
-	expected := joinNewline(
-		`probe_http_got_expected_response{url="http://example.com",method="GET",scenario="s",group="g"} 1`,
-		`probe_http_error_code{url="http://example.com",method="GET",scenario="s",group="g"} 0`,
-		`probe_http_info{tls_version="1.3",proto="1.1",k="v",url="http://example.com",method="GET",scenario="s",group="g"} 1`,
-		`probe_http_requests_total{url="http://example.com",method="GET",scenario="s",group="g"} 2`,
-		`probe_http_requests_failed_total{url="http://example.com",method="GET",scenario="s",group="g"} 1`,
-		`probe_http_status_code{url="http://example.com",method="GET",scenario="s",group="g"} 200`,
-		`probe_http_version{url="http://example.com",method="GET",scenario="s",group="g"} 1.1`,
-		`probe_http_ssl{url="http://example.com",method="GET",scenario="s",group="g"} 1`,
-		`probe_http_duration_seconds_min{phase="resolve",url="http://example.com",method="GET",scenario="s",group="g"} 0`,
-		`probe_http_duration_seconds_max{phase="resolve",url="http://example.com",method="GET",scenario="s",group="g"} 0`,
-		`probe_http_duration_seconds{phase="resolve",url="http://example.com",method="GET",scenario="s",group="g"} 0`,
-		`probe_http_duration_seconds_count{phase="resolve",url="http://example.com",method="GET",scenario="s",group="g"} 2`,
-		`probe_http_duration_seconds_sum{phase="resolve",url="http://example.com",method="GET",scenario="s",group="g"} 0`,
-		`probe_http_duration_seconds_min{phase="connect",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds_max{phase="connect",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds{phase="connect",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds_count{phase="connect",url="http://example.com",method="GET",scenario="s",group="g"} 2`,
-		`probe_http_duration_seconds_sum{phase="connect",url="http://example.com",method="GET",scenario="s",group="g"} 0.002`,
-		`probe_http_duration_seconds_min{phase="tls",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds_max{phase="tls",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds{phase="tls",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds_count{phase="tls",url="http://example.com",method="GET",scenario="s",group="g"} 2`,
-		`probe_http_duration_seconds_sum{phase="tls",url="http://example.com",method="GET",scenario="s",group="g"} 0.002`,
-		`probe_http_duration_seconds_min{phase="processing",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds_max{phase="processing",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds{phase="processing",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds_count{phase="processing",url="http://example.com",method="GET",scenario="s",group="g"} 2`,
-		`probe_http_duration_seconds_sum{phase="processing",url="http://example.com",method="GET",scenario="s",group="g"} 0.002`,
-		`probe_http_duration_seconds_min{phase="transfer",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds_max{phase="transfer",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds{phase="transfer",url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_duration_seconds_count{phase="transfer",url="http://example.com",method="GET",scenario="s",group="g"} 2`,
-		`probe_http_duration_seconds_sum{phase="transfer",url="http://example.com",method="GET",scenario="s",group="g"} 0.002`,
-		`probe_http_total_duration_seconds_min{url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_total_duration_seconds_max{url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_total_duration_seconds{url="http://example.com",method="GET",scenario="s",group="g"} 0.001`,
-		`probe_http_total_duration_seconds_count{url="http://example.com",method="GET",scenario="s",group="g"} 2`,
-		`probe_http_total_duration_seconds_sum{url="http://example.com",method="GET",scenario="s",group="g"} 0.002`,
-	)
-
-	require.Equal(t, expected, buf.String())
 }
 
 func nopLogger() *logrus.Logger {

--- a/output_test.go
+++ b/output_test.go
@@ -110,7 +110,7 @@ func TestMetricStore(t *testing.T) {
 		}
 		gaugeB := metrics.TimeSeries{
 			Metric: &metrics.Metric{
-				Name: "im_gaguge_b",
+				Name: "im_gauge_b",
 				Type: metrics.Gauge,
 			},
 			Tags: nil,

--- a/remove_bench_test.go
+++ b/remove_bench_test.go
@@ -1,0 +1,55 @@
+package sm_test
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"testing"
+)
+
+func BenchmarkRemove(b *testing.B) {
+	// Create a map with 1k keys from 1_000_000 to 1_100_000.
+	haystack := map[string]struct{}{}
+	for i := 0; i < 1000; i++ {
+		key := strconv.Itoa(1_000_000 + 100*i)
+		haystack[key] = struct{}{}
+	}
+
+	for keys := 5; keys <= 20; keys += 5 {
+		b.Run(fmt.Sprintf("%d keys", keys), func(b *testing.B) {
+			// Create a list of #keys needles to found in map. 1 every [lcm(100, 40) / min(100, 40) = 5] needles should be in map.
+			needleSlice := []string{}
+			for i := 0; i < keys; i++ {
+				needleSlice = append(needleSlice, strconv.Itoa(1_000_000+40*i))
+			}
+
+			// Map version of the needle list.
+			needleMap := map[string]bool{}
+			for _, needle := range needleSlice {
+				needleMap[needle] = true
+			}
+
+			b.Run("map", func(b *testing.B) {
+				found := 0
+				for i := 0; i < b.N; i++ {
+					for key := range haystack {
+						if needleMap[key] {
+							found++
+						}
+					}
+				}
+			})
+
+			b.Run("slice", func(b *testing.B) {
+				found := 0
+				for i := 0; i < b.N; i++ {
+					for key := range haystack {
+						if slices.Contains(needleSlice, key) {
+							found++
+						}
+					}
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> **Reviewers**: This PR changes the `output.go` file substantially, making the diff useless. I recommend to look a the new code only, and focus efforts on considering whether the tests are sufficient to prove backwards-compatibility.

This PR overhauls how metrics are processed in the SM output extension, deliberately taking a few tradeoffs against performance to make a code that is going to be chatty and verbose as easy to read as possible.

## How the new code works

The new code works like this:

When samples arrive through `func (o *Output) AddMetricSamples(containers []metrics.SampleContainer)`, samples are added to a map in the `metricStore`. This map indexes metrics by timeseries, with the value being the numeric value of the timeseries. If a sample for a given timeseries arrives more than once, it is immediately aggregated this early, depending on the metric type: Counters are added to its previous value, gauges replace the previous value, and Rates and Trends are averaged. At this point, metrics are aggregated but their labels and names are untouched.

When `func (o *Output) Stop() error` is called, transformation takes place in three steps.

First, new timeseries are *Derived* from existing ones. This includes creating new timeseries by changing the metric name (e.g. adding suffixes), or creating new trimeseries with information contained in another. This process can use one trimeseries to create serveral derived ones, but every derived trimeseries must come exactly from one timeseries output by k6. The derivation process walks through the `metricStore` sequentially and exactly once, so it is no possible to combine multiple k6 metrics, or derive derivates.

Next, some trimeseries are *Removed*. This is done by checking if the metric name is on a "remove list". This step helps to both remove unused metrics, but also to remove trimeseries that we cloned with a new name in the Derive step, effectively allowing us to rename a trimeseries.

Finally, labels are stripped from trimeseries. Some labels are removed from all timeseries, while others are removed from all except some. This process does not aggregate the resulting timeseries in any way, and it is technically possible to obtain duplicated timeseries as a result. This however should be very unlikely in practice as we remove labels that are known to not contribute to cardinality, just noise.

Each transformation step walks through the map once, with the Derivation process being the most expensive as new entries are added to it.

After the transformation is done, metrics are serialized into a prometheus text format and written to the output file.

## Transformations

The following transformations are currently implemented, in the `Derive-Remove-RemoveLabels` process described above:
- Rename `http_reqs` to `http_requests_total`
- Rename `http_req_failed` to `http_requests_failed_total`
- Create `http_info` gauge with info-like labels from `http_reqs`, with a value of  `1`. 
  - `tls_version`, `proto` labels are kept in `http_info` and removed from all other metrics.
- Create `http_ssl` gauge with a value of `1` if `http_reqs` had a `tls_version` label, `0` otherwise.
- Create `http_got_expected_response` gauge, which is 1 if `http_reqs` had the `expected_response` label set to `true`, and 0 otherwise.
  - `expected_response` label is removed from all other metrics.
- Create `http_error_code` gauge, whose value equals the value of the `error_code` label originally present.
  - `error_code` label is removed from all other metrics.
  - `error` label, containing a textual representation from the error, is removed from _all_ metrics.
- Create `http_status_code` gauge, whose value equals the value of the `status` label originally present.
- Create `http_version` gauge, whose value equals the value of the HTTP protocol version parsed from the original `proto` label.
- `data_(sent|received)` metrics are renamed to `data_(sent|received)_bytes`
- `http_req_duration` is renamed and scaled to `http_total_duration_seconds`
- `iteration_duration` is renamed and scaled to `iteration_duration_seconds`
- `http_req_(blocked|connecting|receiving|sending|handshaking|waiting) are converted to `http_duration_seconds` with a `phase` label, with the value of this label being a slightly reworded version of the original (preserving pre-refactor behavior).
- `vus`, `vus_max`, and `iterations` metrics are removed
- `group` label is removed from all metrics
- `checks` metric is renamed to `check_success_rate`
- `checks` metric is emitted as logs
  - `time="2025-01-14T18:21:59+01:00" level=info msg="check result" check="is 200" count=3 metric=checks_total scenario=default value=0.3`
- `checks` is derived into a `checks_total` counter, with a `result="(fail|success)"` label is created from.

This were, to my understanding, all transformations done using the previous approach.

## Opinions

This new approach is deliberately opinionated in a couple regards:
- Everything is aggregated very early and the only value retained for `Trend`s and `Rate`s is the average. This second part is easy to change if the need arises, but so far it doesn't seem to me to be the case, as most of the times we will want to report the average only.
- Readable, dumb code is used for transformations. It might be tempted to extract some to a data-like representation (e.g. a map from old name to new name), but I deliberately chose not to.
- Explicitness and top-down readability are prioritized over performance (within reason). There is an assumption of the number of timeseries that need to be subject to this process (after aggregation) should be relatively small (<1k), for which dumb map operations are considered enough.

## Open ends

1. What to do with the `name` label. It was previously not emitted, and now is. This seems to be the right thing to do according to [k6 maintainers](https://raintank-corp.slack.com/archives/C042WNQFZEZ/p1734458951104669).
2. `checks_total` and the newly added `check_success_rate` now carry a `check` label containing the check name. Before this refactor this label was stripped on the argument of being high-cardinality, but given we're allowing URLs as labels I don't see this being a particularly strong argument. As we cannot perform per-label aggregations, we would need to drop this metric entirely if we want to get rid of the `check` label.