### PR TITLE
Fix CI pipeline for xk6 v0.14.0

### DIFF
--- a/.github/workflows/push-pr-release.yaml
+++ b/.github/workflows/push-pr-release.yaml
@@ -28,6 +28,7 @@ jobs:
           echo "k6=${k6version}" >> $GITHUB_OUTPUT
       - name: Build with xk6
         run: |-
+          mkdir -p dist
           docker run --rm -i -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" \
             -e "GOOS=${{ matrix.goos }}" -e "GOARCH=${{ matrix.goarch }}" \
             grafana/xk6 build ${{ steps.version.outputs.k6 }} \

--- a/.github/workflows/push-pr-release.yaml
+++ b/.github/workflows/push-pr-release.yaml
@@ -33,7 +33,7 @@ jobs:
             -e "GOOS=${{ matrix.goos }}" -e "GOARCH=${{ matrix.goarch }}" \
             grafana/xk6 build ${{ steps.version.outputs.k6 }} \
             --output "dist/sm-k6-${{ matrix.goos }}-${{ matrix.goarch }}" \
-            --with sm=.
+            --with github.com/grafana/xk6-sm=.
       - name: Check runner architecture
         id: runner-info
         run: |-


### PR DESCRIPTION
This worked before, but apparently not anymore. Perhaps due to https://github.com/grafana/xk6/commit/0b160fae329c9079e9546568de157364391b3b0b?

Easy fix, either way.