### PR TITLE
chore: integration: add tests for custom phases

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -222,10 +222,35 @@ func TestSMK6(t *testing.T) {
 				metricLabels: map[string]string{"phase": "processing", "url": "https://test-api.k6.io/public/crocodiles/"},
 				assertValue:  nonZero,
 			},
+			// Custom http phases. Check for each one individually as we use slightly different names than k6 uses.
 			{
-				name:         "HTTP duration seconds has custom 'resolve' phase",
+				name:         "HTTP duration seconds has phase=resolve",
 				metricName:   "probe_http_duration_seconds",
 				metricLabels: map[string]string{"phase": "resolve", "url": "https://test-api.k6.io/public/crocodiles/"},
+				assertValue:  any, // Just fail if not present.
+			},
+			{
+				name:         "HTTP duration seconds has phase=connect",
+				metricName:   "probe_http_duration_seconds",
+				metricLabels: map[string]string{"phase": "connect", "url": "https://test-api.k6.io/public/crocodiles/"},
+				assertValue:  any, // Just fail if not present.
+			},
+			{
+				name:         "HTTP duration seconds has phase=tls",
+				metricName:   "probe_http_duration_seconds",
+				metricLabels: map[string]string{"phase": "tls", "url": "https://test-api.k6.io/public/crocodiles/"},
+				assertValue:  any, // Just fail if not present.
+			},
+			{
+				name:         "HTTP duration seconds has phase=processing",
+				metricName:   "probe_http_duration_seconds",
+				metricLabels: map[string]string{"phase": "processing", "url": "https://test-api.k6.io/public/crocodiles/"},
+				assertValue:  any, // Just fail if not present.
+			},
+			{
+				name:         "HTTP duration seconds has phase=transfer",
+				metricName:   "probe_http_duration_seconds",
+				metricLabels: map[string]string{"phase": "transfer", "url": "https://test-api.k6.io/public/crocodiles/"},
 				assertValue:  any, // Just fail if not present.
 			},
 			{


### PR DESCRIPTION
Small follow-up to https://github.com/grafana/xk6-sm/pull/44

I initially assumed that we were converting from `http_req_XXX` to `probe_http_duration_seconds{phase="XXX"}`, but this is not entirely true: The naming of the phases is actually different.

This test ensures that the current names we use for those phases exist in the output.