### PR TITLE
chore: README: clarify this repo is not to be used by SM end users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # xk6-sm
 
 > [!WARNING]
-> Heads up, Synthetic Monitoring end user: You do not need to build or download this. A k6 binary compiled with this extension is already shipped in our [agent](https://github.com/grafana/synthetic-monitoring-agent) packages.
+> Heads up, Synthetic Monitoring users: You do not need to build or download this. A k6 binary compiled with this extension is already shipped in our [agent](https://github.com/grafana/synthetic-monitoring-agent) packages.
 
 Output k6 extension used by the [synthetic monitoring agent](https://github.com/grafana/synthetic-monitoring-agent).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # xk6-sm
 
+> [!WARNING]
+> Heads up, Synthetic Monitoring end user: You do not need to build or download this. A k6 binary compiled with this extension is already shipped in our [agent](https://github.com/grafana/synthetic-monitoring-agent) packages.
+
 Output k6 extension used by the [synthetic monitoring agent](https://github.com/grafana/synthetic-monitoring-agent).
 
 ## Build


### PR DESCRIPTION
We've seen at least one instance of a customer mistakenly thinking they need to download and install this extension, or the binaries provided. This is not the case, the k6 binary with the appropriate extensions is already packaged in all our agent distributables (container image and linux distro packages).

This adds a fancy looking warning box that should help clarify that in case anyone ends up in this repo.

![image](https://github.com/user-attachments/assets/cb6ff79d-e12a-41ba-8824-f0ee39f0ab0f)
