### PR TITLE
fix: correctly handle `__raw_url__` by replacing url with it if present

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -156,6 +156,7 @@ func TestSMK6(t *testing.T) {
 			"error":             {"probe_http_info"},
 			"expected_response": {"probe_http_got_expected_response"},
 			"group":             {},
+			"__raw_url__":       {},
 		}
 
 		for _, mf := range mfs {
@@ -318,6 +319,12 @@ func TestSMK6(t *testing.T) {
 				// Test for a paticular URL to avoid matching a failed request, which has no TLS version.
 				metricLabels: map[string]string{"tls_version": "1.3", "url": "https://test-api.k6.io/public/crocodiles/"},
 				assertValue:  any, // Just fail if not present.
+			},
+			{
+				name:         "__raw_url__ overrides url",
+				metricName:   "probe_http_requests_total",
+				metricLabels: map[string]string{"url": "foobar"},
+				assertValue:  equals(1),
 			},
 		} {
 			tc := tc

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -42,9 +42,8 @@ func TestSMK6(t *testing.T) {
 
 	cmd := exec.CommandContext(ctx, smk6, "run", "-", "-o=sm="+outFile)
 	cmd.Stdin = bytes.NewReader(testScript)
-	err = cmd.Run()
-	if err != nil {
-		t.Fatalf("running sm-k6: %v", err)
+	if k6out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("running sm-k6: %v\n%s", errors.Join(err, ctx.Err()), string(k6out))
 	}
 
 	out, err := os.Open(outFile)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -35,7 +35,7 @@ func TestSMK6(t *testing.T) {
 		t.Fatalf("sm-k6 binary does not seem to exist, must be compiled before running this test: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	t.Cleanup(cancel)
 
 	outFile := filepath.Join(t.TempDir(), "metrics.txt")

--- a/integration/test-script.js
+++ b/integration/test-script.js
@@ -39,7 +39,12 @@ export default function () {
   http.get(`http://${testHost}`); // non-https.
   http.get(`https://${testHost}/public/crocodiles/`);
   http.get(`https://${testHost}/public/crocodiles2/`); // 404
-  http.get(`https://${testHost}/public/crocodiles3/`); // 404
+  http.get(`https://${testHost}/public/crocodiles3/`, {
+    tags: {
+      // Used by multihttp scripts to store the user-defiend URL before interpolation.
+      '__raw_url__': 'foobar',
+    }
+  }); // 404
   http.get(`https://${testHost}/public/crocodiles4/`); // 404
   http.get(`https://${testHost}/public/crocodiles4/`); // Second 404, to assert differences between failure rate and counter.
   http.get(`http://fail.internal/public/crocodiles4/`); // failed

--- a/output.go
+++ b/output.go
@@ -415,6 +415,13 @@ func (ms *metricStore) RemoveLabels() {
 		// High cardinality label. This is already present in logs.
 		ts.tags = ts.tags.Without("error")
 
+		// Replace url with __raw_url__ if the latter is present. The agent sets this tag on multihttp checks to be the
+		// user-specified URL, before interpolating variables in it.
+		if rawURL, found := ts.tags.Get("__raw_url__"); found && rawURL != "" {
+			log.Tracef("Overwriting url tag with __raw_url__ on %q", ts.name)
+			ts.tags = ts.tags.Without("__raw_url__").With("url", rawURL)
+		}
+
 		newStore[ts] = v
 	}
 


### PR DESCRIPTION
This PR introduced special handling for the `__raw_url__` tag, which matches what the agent would expect as per https://github.com/grafana/synthetic-monitoring-agent/pull/683.

It also adds tests to assert that the label is correclty replaced, and that `__raw_url__` is removed from the output, as otherwise it would make the output invalid as per the prometheus spec.