### PR TITLE
Run integration tests against a local server, other improvements

### DIFF
--- a/integration/test-script.js
+++ b/integration/test-script.js
@@ -2,7 +2,8 @@ import { check } from 'k6';
 import http from 'k6/http';
 import { Trend, Counter, Gauge } from 'k6/metrics';
 
-const testHost = __ENV.TEST_HOST ? __ENV.TEST_HOST : "test-api.k6.io";
+const httpHost = __ENV.TEST_HTTP_HOST ? __ENV.TEST_HTTP_HOST : "test-api.k6.io";
+const httpsHost = __ENV.TEST_HTTPS_HOST ? __ENV.TEST_HTTPS_HOST : "test-api.k6.io";
 
 const myTrend = new Trend('waiting_time');
 const myCounter = new Counter('my_counter');
@@ -36,11 +37,11 @@ export default function () {
     }
   );
 
-  http.get(`http://${testHost}`); // non-https.
-  http.get(`https://${testHost}/public/crocodiles/`);
-  http.get(`https://${testHost}/public/crocodiles2/`); // 404
-  http.get(`https://${testHost}/public/crocodiles3/`); // 404
-  http.get(`https://${testHost}/public/crocodiles4/`); // 404
-  http.get(`https://${testHost}/public/crocodiles4/`); // Second 404, to assert differences between failure rate and counter.
+  http.get(`${httpHost}`); // non-https.
+  http.get(`${httpsHost}/public/crocodiles/`);
+  http.get(`${httpsHost}/public/crocodiles2/`); // 404
+  http.get(`${httpsHost}/public/crocodiles3/`); // 404
+  http.get(`${httpsHost}/public/crocodiles4/`); // 404
+  http.get(`${httpsHost}/public/crocodiles4/`); // Second 404, to assert differences between failure rate and counter.
   http.get(`http://fail.internal/public/crocodiles4/`); // failed
 }


### PR DESCRIPTION
Testing against test-api.k6.io introduces reliability problems and may make the test flaky if the service is not responsive. Additionally, this includes some minor changes like logging the k6 output.

This one is actually an RFC as well: I'm curious on your opinions about this change, mainly whether you see the additional complexity worth it, or if you'd rather point to a more reliable online service.