### PR TITLE
feat: build a second binary with the Grafana secrets manager client extension

### DIFF
--- a/.github/workflows/push-pr-release.yaml
+++ b/.github/workflows/push-pr-release.yaml
@@ -42,7 +42,7 @@ jobs:
             -e "GOOS=${{ matrix.goos }}" -e "GOARCH=${{ matrix.goarch }}" \
             grafana/xk6 build ${{ steps.version.outputs.k6 }} \
             --output "dist/sm-k6-${{ matrix.goos }}-${{ matrix.goarch }}-gsm" \
-            --with github.com/grafana/xk6-sm=.
+            --with github.com/grafana/xk6-sm=. \
             --with github.com/grafana/gsm-api-go-client@64c2eb5
       - name: Check runner architecture
         id: runner-info

--- a/.github/workflows/push-pr-release.yaml
+++ b/.github/workflows/push-pr-release.yaml
@@ -34,6 +34,15 @@ jobs:
             grafana/xk6 build ${{ steps.version.outputs.k6 }} \
             --output "dist/sm-k6-${{ matrix.goos }}-${{ matrix.goarch }}" \
             --with github.com/grafana/xk6-sm=.
+      - name: Build with xk6 and gsm
+        run: |-
+          mkdir -p dist
+          docker run --rm -i -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" \
+            -e "GOOS=${{ matrix.goos }}" -e "GOARCH=${{ matrix.goarch }}" \
+            grafana/xk6 build ${{ steps.version.outputs.k6 }} \
+            --output "dist/sm-k6-${{ matrix.goos }}-${{ matrix.goarch }}-gsm" \
+            --with github.com/grafana/xk6-sm=.
+            --with github.com/grafana/gsm-api-go-client
       - name: Check runner architecture
         id: runner-info
         run: |-

--- a/.github/workflows/push-pr-release.yaml
+++ b/.github/workflows/push-pr-release.yaml
@@ -34,6 +34,7 @@ jobs:
             grafana/xk6 build ${{ steps.version.outputs.k6 }} \
             --output "dist/sm-k6-${{ matrix.goos }}-${{ matrix.goarch }}" \
             --with github.com/grafana/xk6-sm=.
+      # TODO(d0ugal): Remove this once the above build catches up and downstream consumers are updated.
       - name: Build with xk6 and gsm
         run: |-
           mkdir -p dist
@@ -42,7 +43,7 @@ jobs:
             grafana/xk6 build ${{ steps.version.outputs.k6 }} \
             --output "dist/sm-k6-${{ matrix.goos }}-${{ matrix.goarch }}-gsm" \
             --with github.com/grafana/xk6-sm=.
-            --with github.com/grafana/gsm-api-go-client
+            --with github.com/grafana/gsm-api-go-client@64c2eb5
       - name: Check runner architecture
         id: runner-info
         run: |-


### PR DESCRIPTION
This is a temporary workaround to allow us to build a unstable k6 which will only be used when secrets are present for the script.

In the future this should be removed and it should be included in the stable release.

This depends on https://github.com/grafana/gsm-api-go-client/pull/1