### PR TITLE
feat: do not output timeseries whose `resource_type` does not match an allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 
 Output k6 extension used by the [synthetic monitoring agent](https://github.com/grafana/synthetic-monitoring-agent).
 
+## Configuration
+
+By default, this extension will drop all metrics which have a `resource_type` tag when the value for the tag is not `Document`. This is done to avoid generating metrics for every URL that a k6 script using browser would normally generate, including those for images, scripts, and others.
+
+This `resource_type` allowlist is configurable by means of the `SM_K6_BROWSER_RESOURCE_TYPES` environment variable, which should be set to a comma-separated list of `resource_type`s that should not be dropped. The list of known `resource_type`s can be found [here](https://github.com/grafana/k6/blob/v0.57.0/internal/js/modules/k6/browser/common/http.go#L25).
+
+This matching is case-insensitive, and the special value `*` will cause every `resource_type` to be retained. Conversely, an empty list will cause all metrics from browser to be omitted.
+
 ## Build
 
 Use [xk6](https://github.com/grafana/xk6). See the CI/CD pipelines for a full example of a build command.


### PR DESCRIPTION
First take at browser metric filtering. This PR adds an allowlist of values for the `resource_type` tag, which k6 browser uses to indicate what prompted a request.

The code roughly works as follows: After removing timeseries by metric name as it was previously done, the list of timeseries is walked again. If a timeseries contains the `resource_type` label, and the value for that label is not present in the allowlist, the timeseries is yeeted. The allowlist is case-insensitive.

The allowlist itself defaults to just `document`, which means HTTP requests initiated by loading a webpage. This allowlist can be configured using the `SM_K6_BROWSER_RESOURCE_TYPES` environment variable, as a comma-separated list of valid `resource_type`s. The special value `*`, if present, allows all `resource_type`s and thus skips this second walk entirely.

A couple of integration tests, with different levels of granularity are added, both to cover the removal functionality and the handling of the `SM_K6_BROWSER_RESOURCE_TYPES` variable.

The mechanism by which a user can specify this allowlist in the SM UI/API and then have that value traverse its way here is out of the scope of this PR. Whether we want to merge this (breaking) change before or after merging this is also out of scope: If we chose to merge this first, then we can make the change non-breaking to users by setting `SM_K6_BROWSER_RESOURCE_TYPES=*` in the runner.