### PR TITLE
chore: integration: add tests for browser scripts and metrics

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,4 +5,17 @@
     "github>grafana/sm-renovate//presets/synthetic-monitoring.json5",
     "github>grafana/sm-renovate//presets/go.json5",
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/grafana/crocochrome",
+      "fileMatch": [
+        "_test.go$",
+      ],
+      "matchStrings": [
+        "ghcr.io/grafana/crocochrome:(?<currentValue>[\\w.-]+)(?:@(?<currentDigest>[\\w:]+))?",
+      ]
+    },
+  ]
 }

--- a/integration/browser-script.js
+++ b/integration/browser-script.js
@@ -1,0 +1,30 @@
+import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+export default async function () {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    // e-commerce site as a torture test for metric generation.
+    await page.goto('https://www.amazon.com');
+  } finally {
+    await page.close();
+  }
+}

--- a/integration/integration_browserutils_test.go
+++ b/integration/integration_browserutils_test.go
@@ -1,0 +1,140 @@
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	prometheus "github.com/prometheus/client_model/go"
+)
+
+// runCrocochrome executes `docker run` for the crocochrome image, forwarding port 8080 to the host.
+// When the test finishes, the container is (hopefully) killed.
+func runCrocochrome(t *testing.T) {
+	t.Helper()
+
+	const crocochromeImage = "ghcr.io/grafana/crocochrome:v0.5.0@sha256:8919c5ff1808d4cb4342c9ffa1311f673eec5ee2ec1e95c92730420a8d87087a"
+	t.Logf("Starting crocochrome %s", crocochromeImage)
+	dockerCmd := exec.Command("docker", "run", "--rm", "-i", "-p", "8080:8080", crocochromeImage)
+	dockerCmd.Stderr = os.Stderr
+	err := dockerCmd.Start()
+	if err != nil {
+		t.Fatalf("starting crocochrome container: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = dockerCmd.Wait()
+	})
+	t.Cleanup(func() {
+		if dockerCmd.Process == nil {
+			return
+		}
+
+		_ = dockerCmd.Process.Signal(os.Interrupt)
+	})
+
+	// Wait until crocochrome is reachable.
+	readinessCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	for {
+		req, err := http.NewRequestWithContext(readinessCtx, http.MethodGet, "http://localhost:8080/metrics", nil)
+		if err != nil {
+			t.Fatalf("building crocochrome health request: %v", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+
+		if err == nil && resp.StatusCode == http.StatusOK {
+			t.Logf("Crocochrome up and running")
+			return
+		}
+
+		if errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Timeout starting crocochrome: %v", err)
+		}
+
+		if ps := dockerCmd.ProcessState; ps != nil {
+			t.Fatalf("Crocochrome exited with code %v", ps.ExitCode())
+		}
+
+		t.Logf("Crocochrome not ready yet")
+		time.Sleep(time.Second)
+	}
+}
+
+// runBrowserScript wraps runScript, creating a crocochrome session before running k6 and passing the right WS url to
+// it. The session is deleted when k6 returns.
+func runBrowserScript(t *testing.T, scriptFileName string, env []string) []*prometheus.MetricFamily {
+	t.Helper()
+
+	endpoint := "http://localhost:8080"
+
+	session, err := createSession(endpoint)
+	if err != nil {
+		t.Fatalf("creating crocochrome session: %v", err)
+	}
+
+	defer func() {
+		err := deleteSession(endpoint, session.ID)
+		if err != nil {
+			t.Fatalf("deleting crocochrome session: %v", err)
+		}
+	}()
+
+	env = append(env, "K6_BROWSER_WS_URL="+session.ChromiumVersion.WebSocketDebuggerURL)
+	return runScript(t, scriptFileName, env)
+}
+
+type sessionInfo struct {
+	ID              string `json:"id"`
+	ChromiumVersion struct {
+		WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+	} `json:"chromiumVersion"`
+}
+
+// createSession uses the crocochrome API to start a browser session.
+func createSession(endpoint string) (*sessionInfo, error) {
+	resp, err := http.Post(endpoint+"/sessions", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("got unexpected status %d", resp.StatusCode)
+	}
+
+	session := sessionInfo{}
+	err = json.NewDecoder(resp.Body).Decode(&session)
+	if err != nil {
+		return nil, err
+	}
+
+	return &session, nil
+}
+
+// deleteSession calls the crocochrome API to delete a session.
+func deleteSession(endpoint, sessionID string) error {
+	req, err := http.NewRequest(http.MethodDelete, endpoint+"/sessions/"+sessionID, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("got unexpected status %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -387,6 +387,41 @@ func TestSMK6(t *testing.T) {
 	})
 }
 
+func TestSMK6Browser(t *testing.T) {
+	t.Parallel()
+
+	runCrocochrome(t)
+
+	t.Run("default settings", func(t *testing.T) {
+		// Do not run this one in parallel, as crocochrome only supports one concurrent script run.
+
+		mfs := runBrowserScript(t, "browser-script.js", nil) // Default allowlist.
+
+		t.Run("includes expected metrics", func(t *testing.T) {
+			t.Parallel()
+
+			wanted := []string{
+				"probe_browser_data_received",
+				"probe_browser_data_sent",
+				"probe_browser_http_req_duration",
+				"probe_browser_http_req_failed",
+				"probe_browser_web_vital_cls",
+				"probe_browser_web_vital_fcp",
+				"probe_browser_web_vital_lcp",
+				"probe_browser_web_vital_ttfb",
+			}
+			for _, w := range wanted {
+				if !slices.ContainsFunc(mfs, func(mf *prometheus.MetricFamily) bool {
+					return *mf.Name == w
+				}) {
+					t.Log(mfs)
+					t.Fatalf("Missing metric %q", w)
+				}
+			}
+		})
+	})
+}
+
 func equals(expected float64) func(float64) bool {
 	return func(v float64) bool {
 		return v == expected


### PR DESCRIPTION
This adds a browser script to the integration test suite, which for now only tests for presence of a couple trivial metrics.

Now, of course that makes the thing look easier than it is: To run browser tests we need a browser, and to run browser tests on CI/CD we need to either be reckless and install chromium on the GitHub runners, or to use Crocochrome. As I think we all like the second alternative better, this PR introduces Crocochrome.

Even though the croc simplifies things a lot, there are a couple things that tests need to take care of:
1. Start and stop the crocochrome container
1. Create and destroy sessions using the crocochrome API.

In https://github.com/grafana/sm-k6-runner/pull/201/, which did a very similar thing for the runner, I chose to use testcontainers for crocochrome, mainly because the testcontainers dep was already there. Here, I'm trying to see how crazy it would be to not use testcontainers, and instead YOLO-run `docker` commands.

Looking forward to reviewer's thoughts on how that looks: If someone strongly opposes to trying this as an experiment, I can fall back to testcontainers and its gazillion dependencies. If there's no strong opposition, I suggest we give this a try: Falling back to testcontainers if this is flaky should be close to no effort.

As for the crocochrome API, a couple of quick & dirty functions are implemented to use it.