### PR TITLE
chore: remove unused renovate-app.json

### DIFF
--- a/.github/renovate-app.json
+++ b/.github/renovate-app.json
@@ -1,7 +1,0 @@
-{
-  "customEnvVariables": {
-    "GOPRIVATE": "github.com/grafana",
-    "GONOSUMDB": "github.com/grafana",
-    "GONOPROXY": "github.com/grafana"
-  }
-}


### PR DESCRIPTION
This file is unused by https://github.com/grafana/sm-renovate.