### PR TITLE
ci: run renovate dry-run only on PRs related to renovate

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -5,7 +5,8 @@ on:
     - cron: "29 */4 * * *"
   workflow_dispatch:
   pull_request:
-
+    paths:
+      - '**renovate*'
 jobs:
   renovate:
     permissions:


### PR DESCRIPTION
Running renovate is time-expensive. It takes time on our runners, and also generates a sizeable amount of requests to GitHub and other services.

This PR makes us better netizens by running the dry-run mode of renovate only when something plausibly related to renovate changes.

If we want to test renovate on a PR that changes something else, we can temporarily create a file named `renovate` anywhere and that will trip the loose filter.