### PR TITLE
integration/test: replace test-api, improve logging

### DIFF
--- a/integration/integration_browserutils_test.go
+++ b/integration/integration_browserutils_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -107,8 +108,11 @@ func createSession(endpoint string) (*sessionInfo, error) {
 		return nil, err
 	}
 
+	defer resp.Body.Close() //nolint:errcheck // Skipping for brevity in test context.
+
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("got unexpected status %d", resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("got unexpected status %d:\n%s", resp.StatusCode, string(body))
 	}
 
 	session := sessionInfo{}
@@ -132,8 +136,11 @@ func deleteSession(endpoint, sessionID string) error {
 		return err
 	}
 
+	defer resp.Body.Close() //nolint:errcheck // Skipping for brevity in test context.
+
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("got unexpected status %d", resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("got unexpected status %d:\n%s", resp.StatusCode, string(body))
 	}
 
 	return nil

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -229,105 +229,105 @@ func TestSMK6(t *testing.T) {
 			{
 				name:         "HTTP duration second has a duration-ish value",
 				metricName:   "probe_http_duration_seconds",
-				metricLabels: map[string]string{"phase": "processing", "url": "https://test-api.k6.io/public/crocodiles/"},
+				metricLabels: map[string]string{"phase": "processing", "url": "https://quickpizza.grafana.com/login"},
 				assertValue:  nonZero,
 			},
 			// Custom http phases. Check for each one individually as we use slightly different names than k6 uses.
 			{
 				name:         "HTTP duration seconds has phase=resolve",
 				metricName:   "probe_http_duration_seconds",
-				metricLabels: map[string]string{"phase": "resolve", "url": "https://test-api.k6.io/public/crocodiles/"},
+				metricLabels: map[string]string{"phase": "resolve", "url": "https://quickpizza.grafana.com/login"},
 				assertValue:  any, // Just fail if not present.
 			},
 			{
 				name:         "HTTP duration seconds has phase=connect",
 				metricName:   "probe_http_duration_seconds",
-				metricLabels: map[string]string{"phase": "connect", "url": "https://test-api.k6.io/public/crocodiles/"},
+				metricLabels: map[string]string{"phase": "connect", "url": "https://quickpizza.grafana.com/login"},
 				assertValue:  any, // Just fail if not present.
 			},
 			{
 				name:         "HTTP duration seconds has phase=tls",
 				metricName:   "probe_http_duration_seconds",
-				metricLabels: map[string]string{"phase": "tls", "url": "https://test-api.k6.io/public/crocodiles/"},
+				metricLabels: map[string]string{"phase": "tls", "url": "https://quickpizza.grafana.com/login"},
 				assertValue:  any, // Just fail if not present.
 			},
 			{
 				name:         "HTTP duration seconds has phase=processing",
 				metricName:   "probe_http_duration_seconds",
-				metricLabels: map[string]string{"phase": "processing", "url": "https://test-api.k6.io/public/crocodiles/"},
+				metricLabels: map[string]string{"phase": "processing", "url": "https://quickpizza.grafana.com/login"},
 				assertValue:  any, // Just fail if not present.
 			},
 			{
 				name:         "HTTP duration seconds has phase=transfer",
 				metricName:   "probe_http_duration_seconds",
-				metricLabels: map[string]string{"phase": "transfer", "url": "https://test-api.k6.io/public/crocodiles/"},
+				metricLabels: map[string]string{"phase": "transfer", "url": "https://quickpizza.grafana.com/login"},
 				assertValue:  any, // Just fail if not present.
 			},
 			{
 				name:         "Error code for request that should succeed",
 				metricName:   "probe_http_error_code",
-				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles/"},
+				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/login"},
 				assertValue:  equals(0),
 			},
 			{
 				name:         "Error code for request that should fail",
 				metricName:   "probe_http_error_code",
-				metricLabels: map[string]string{"url": "http://fail.internal/public/crocodiles4/"},
+				metricLabels: map[string]string{"url": "http://fail.internal/failure-nxdomain"},
 				assertValue:  equals(1101),
 			},
 			{
 				name:         "HTTP status code for a request that should succeed",
 				metricName:   "probe_http_status_code",
-				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles/"},
+				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/login"},
 				assertValue:  equals(200),
 			},
 			{
 				name:         "Expected response for a request that should succeed",
 				metricName:   "probe_http_got_expected_response",
-				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles/"},
+				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/login"},
 				assertValue:  equals(1),
 			},
 			{
 				name:         "Expected response for a request that should fail",
 				metricName:   "probe_http_got_expected_response",
-				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles2/"},
+				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/thats-a-404"},
 				assertValue:  equals(0),
 			},
 			{
 				name:         "Total requests for a URL accessed once",
 				metricName:   "probe_http_requests_total",
-				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles/"},
+				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/login"},
 				assertValue:  equals(1),
 			},
 			{
 				name:         "Total requests for a URL accessed twice",
 				metricName:   "probe_http_requests_total",
-				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles4/"},
+				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/thats-another-404-accessed-twice"},
 				assertValue:  equals(2),
 			},
 			{
 				name:         "HTTP requests failed rate",
 				metricName:   "probe_http_requests_failed",
-				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles4/"},
+				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/thats-another-404-accessed-twice"},
 				assertValue:  equals(1),
 			},
 			{
-				name:         "HTTP requests failed ttoal",
+				name:         "HTTP requests failed total",
 				metricName:   "probe_http_requests_failed_total",
-				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles4/"},
+				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/thats-another-404-accessed-twice"},
 				assertValue:  equals(2),
 			},
 			{
 				name:         "HTTP version",
 				metricName:   "probe_http_version",
-				metricLabels: map[string]string{"url": "https://test-api.k6.io/public/crocodiles/"},
+				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/login"},
 				assertValue:  func(f float64) bool { return f >= 1.1 },
 			},
 			{
 				name:       "TLS version label value",
 				metricName: "probe_http_info",
 				// Test for a paticular URL to avoid matching a failed request, which has no TLS version.
-				metricLabels: map[string]string{"tls_version": "1.3", "url": "https://test-api.k6.io/public/crocodiles/"},
+				metricLabels: map[string]string{"tls_version": "1.3", "url": "https://quickpizza.grafana.com/login"},
 				assertValue:  any, // Just fail if not present.
 			},
 			{

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -45,9 +45,12 @@ func runScript(t *testing.T, scriptFileName string, env []string) []*prometheus.
 	cmd := exec.CommandContext(ctx, smk6, "run", "-", "-o=sm="+outFile)
 	cmd.Stdin = bytes.NewReader(script)
 	cmd.Env = env
-	if k6out, err := cmd.CombinedOutput(); err != nil {
+	k6out, err := cmd.CombinedOutput()
+	if err != nil {
 		t.Fatalf("running sm-k6: %v\n%s", errors.Join(err, ctx.Err()), string(k6out))
 	}
+
+	t.Logf("k6 output:\n%s", string(k6out))
 
 	out, err := os.Open(outFile)
 	if err != nil {

--- a/integration/test-script.js
+++ b/integration/test-script.js
@@ -2,7 +2,7 @@ import { check } from 'k6';
 import http from 'k6/http';
 import { Trend, Counter, Gauge } from 'k6/metrics';
 
-const testHost = __ENV.TEST_HOST ? __ENV.TEST_HOST : "test-api.k6.io";
+const testHost = __ENV.TEST_HOST ? __ENV.TEST_HOST : "quickpizza.grafana.com";
 
 const myTrend = new Trend('waiting_time');
 const myCounter = new Counter('my_counter');
@@ -36,16 +36,16 @@ export default function () {
     }
   );
 
-  http.get(`http://${testHost}`); // non-https.
-  http.get(`https://${testHost}/public/crocodiles/`);
-  http.get(`https://${testHost}/public/crocodiles2/`); // 404
-  http.get(`https://${testHost}/public/crocodiles3/`, {
+  http.get(`http://${testHost}/login`); // non-https.
+  http.get(`https://${testHost}/login`);
+  http.get(`https://${testHost}/thats-a-404`); // 404
+  http.get(`https://${testHost}/thats-another-404-accessed-twice`); // 404
+  http.get(`https://${testHost}/thats-another-404-accessed-twice`); // Second 404, to assert differences between failure rate and counter.
+  http.get(`https://${testHost}/404-with-raw-url-tag`, {
     tags: {
       // Used by multihttp scripts to store the user-defiend URL before interpolation.
       '__raw_url__': 'foobar',
     }
   }); // 404
-  http.get(`https://${testHost}/public/crocodiles4/`); // 404
-  http.get(`https://${testHost}/public/crocodiles4/`); // Second 404, to assert differences between failure rate and counter.
-  http.get(`http://fail.internal/public/crocodiles4/`); // failed
+  http.get(`http://fail.internal/failure-nxdomain`); // failed
 }


### PR DESCRIPTION
`test-api.k6.io` now redirects to `quickpizza.grafana.com`, which caused integration tests to break. This PR changes URLs around so we use the latter to bring integration tests back to life.

Eventually we should rebase #73 and move forward with a local server, but this was easier in the meantime.

Additionally, this PR adds a few `t.Log` lines to echo the raw metric output when a test fails. This should help to surface information when a test fails, specially on CI.