### PR TITLE
chore: renovate: automate updates for k6-testing library on tests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,6 +29,17 @@
       "matchStrings": [
         "--with github.com/grafana/gsm-api-go-client@(?<currentDigest>[a-f0-9]{7,40})"
       ]
+    },
+    {
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "grafana/k6-jslib-testing",
+      "fileMatch": [
+        "\\.js$"
+      ],
+      "matchStrings": [
+        "https://jslib.k6.io/k6-utils/(?<currentValue>[^/]+)/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
We use the k6-testing library on tests, it would be good to have it up to date.