### PR TITLE
chore: integration: increase number of tolerable Document-type TS to 5

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -450,7 +450,7 @@ func TestSMK6Browser(t *testing.T) {
 			t.Parallel()
 
 			for _, mf := range mfs {
-				sane := 3
+				sane := 5
 				if found := len(mf.Metric); found > sane {
 					t.Fatalf("Found suspicioulsy large number of timeseries (%d>%d) for metric %q", found, sane, *mf.Name)
 				}


### PR DESCRIPTION
Amazon.com now also loads an iframe for ad-related purposes, increasing the number of timeseries. This is okay.