### PR TITLE
chore: update go toolchain to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/xk6-sm
 
 go 1.23.6
 
-toolchain go1.24.5
+toolchain go1.24.6
 
 require (
 	github.com/grafana/gsm-api-go-client v0.2.0


### PR DESCRIPTION
Renovate is now trying to update to 1.25.0, which makes golangci-lint fail (as usual).
Manually update this one to get rid of CVE alerts in dependent images.