### PR TITLE
fix: Restore integration test suite

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -207,7 +207,7 @@ linters:
         - github.com/jackc/pgx/v5\.Tx
     lll:
       line-length: 120
-      tab-width: 8
+      tab-width: 4
     maintidx:
       under: 20
     mnd:

--- a/README.md
+++ b/README.md
@@ -22,15 +22,14 @@ operating system / architecture). The resulting binaries will be found in the
 The extension is built using [xk6](https://github.com/grafana/xk6).
 
 ## Test
-Unit tests:
+Running unit tests only:
 ```
-make test
+$ make test
 ```
 
-All tests (including integration):
+Running all tests, including integration tests (requires Docker):
 ```
-# Note: Requires Docker
-GO_TEST_BUILD_TAGS="-tags=integration" make test
+$ make test TEST_SHORT=false
 ```
 
 ## Release process

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ operating system / architecture). The resulting binaries will be found in the
 
 The extension is built using [xk6](https://github.com/grafana/xk6).
 
+## Test
+Unit tests:
+```
+make test
+```
+
+All tests (including integration):
+```
+# Note: Requires Docker
+GO_TEST_BUILD_TAGS="-tags=integration" make test
+```
+
 ## Release process
 
 Merge the release PR created by release-please. Once a release is created in github, a CI/CD pipeline will build the artifacts and attach them to the release.

--- a/integration/integration_browserutils_test.go
+++ b/integration/integration_browserutils_test.go
@@ -27,7 +27,18 @@ func runCrocochrome(t *testing.T) {
 
 	const crocochromeImage = "ghcr.io/grafana/crocochrome:v0.10.2@sha256:294f0378efa0263363a394f6be193206aa4210b9c3a1e59dec2a637693428e15"
 	t.Logf("Starting crocochrome %s", crocochromeImage)
-	dockerCmd := exec.Command("docker", "run", "--rm", "-i", "-p", "8080:8080", crocochromeImage)
+
+	readinessEndpoint := "http://localhost:8080/metrics"
+	dockerArgs := []string{"run", "--rm", "-i", "-p", "8080:8080"}
+	if os.Getenv("CI") != "" {
+		// We're running on CI/CD. Give the container a name so we can connect to it.
+		dockerArgs = append(dockerArgs, "--name", "crocochrome")
+		readinessEndpoint = "http://crocochrome:8080/metrics"
+	}
+
+	dockerArgs = append(dockerArgs, crocochromeImage)
+
+	dockerCmd := exec.Command("docker", dockerArgs...)
 	dockerCmd.Stderr = os.Stderr
 	err := dockerCmd.Start()
 	if err != nil {
@@ -49,7 +60,7 @@ func runCrocochrome(t *testing.T) {
 	readinessCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	for {
-		req, err := http.NewRequestWithContext(readinessCtx, http.MethodGet, "http://localhost:8080/metrics", nil)
+		req, err := http.NewRequestWithContext(readinessCtx, http.MethodGet, readinessEndpoint, nil)
 		if err != nil {
 			t.Fatalf("building crocochrome health request: %v", err)
 		}
@@ -82,6 +93,10 @@ func runBrowserScript(t *testing.T, scriptFileName string, env []string) []*prom
 	t.Helper()
 
 	endpoint := "http://localhost:8080"
+	if os.Getenv("CI") != "" {
+		// Use container name
+		endpoint = "http://crocochrome:8080"
+	}
 
 	session, err := createSession(endpoint)
 	if err != nil {

--- a/integration/integration_browserutils_test.go
+++ b/integration/integration_browserutils_test.go
@@ -28,19 +28,29 @@ func runCrocochrome(t *testing.T) {
 	const crocochromeImage = "ghcr.io/grafana/crocochrome:v0.10.2@sha256:294f0378efa0263363a394f6be193206aa4210b9c3a1e59dec2a637693428e15"
 	t.Logf("Starting crocochrome %s", crocochromeImage)
 
+	// Pull image ahead of time to avoid race condition with readiness probe.
+	pullOut, err := exec.Command("docker", "pull", crocochromeImage).CombinedOutput()
+	if err != nil {
+		t.Fatalf("pulling crocochrome image: %v\n%s", err, pullOut)
+	}
+
 	readinessEndpoint := "http://localhost:8080/metrics"
 	dockerArgs := []string{"run", "--rm", "-i", "-p", "8080:8080"}
 	if os.Getenv("CI") != "" {
-		// We're running on CI/CD. Give the container a name so we can connect to it.
-		dockerArgs = append(dockerArgs, "--name", "crocochrome")
-		readinessEndpoint = "http://crocochrome:8080/metrics"
+		hostname, err := os.Hostname()
+		if err != nil {
+			t.Fatalf("getting hostname for container ID: %v", err)
+		}
+		// Share the job container's network namespace so crocochrome is
+		// reachable at localhost. Port mapping is not allowed in this mode.
+		dockerArgs = []string{"run", "--rm", "-i", "--network=container:" + hostname}
 	}
 
 	dockerArgs = append(dockerArgs, crocochromeImage)
 
 	dockerCmd := exec.Command("docker", dockerArgs...)
 	dockerCmd.Stderr = os.Stderr
-	err := dockerCmd.Start()
+	err = dockerCmd.Start()
 	if err != nil {
 		t.Fatalf("starting crocochrome container: %v", err)
 	}
@@ -93,10 +103,6 @@ func runBrowserScript(t *testing.T, scriptFileName string, env []string) []*prom
 	t.Helper()
 
 	endpoint := "http://localhost:8080"
-	if os.Getenv("CI") != "" {
-		// Use container name
-		endpoint = "http://crocochrome:8080"
-	}
 
 	session, err := createSession(endpoint)
 	if err != nil {

--- a/integration/integration_browserutils_test.go
+++ b/integration/integration_browserutils_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Grafana Labs.
+// Copyright (C) 2026 Grafana Labs.
 // SPDX-License-Identifier: AGPL-3.0-only
 
 //go:build integration
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	prometheus "github.com/prometheus/client_model/go"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // runCrocochrome executes `docker run` for the crocochrome image, forwarding port 8080 to the host.
@@ -25,17 +25,22 @@ import (
 func runCrocochrome(t *testing.T) {
 	t.Helper()
 
-	const crocochromeImage = "ghcr.io/grafana/crocochrome:v0.10.2@sha256:294f0378efa0263363a394f6be193206aa4210b9c3a1e59dec2a637693428e15"
+	const crocochromeImage = "ghcr.io/grafana/crocochrome:" +
+		"v0.10.2@sha256:294f0378efa0263363a394f6be193206aa4210b9c3a1e59dec2a637693428e15"
 	t.Logf("Starting crocochrome %s", crocochromeImage)
 
 	// Pull image ahead of time to avoid race condition with readiness probe.
-	pullOut, err := exec.Command("docker", "pull", crocochromeImage).CombinedOutput()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer cancel()
+
+	pullOut, err := exec.CommandContext(ctx, "docker", "pull", crocochromeImage).CombinedOutput()
 	if err != nil {
 		t.Fatalf("pulling crocochrome image: %v\n%s", err, pullOut)
 	}
 
 	readinessEndpoint := "http://localhost:8080/metrics"
-	dockerArgs := []string{"run", "--rm", "-i", "-p", "8080:8080"}
+	dockerArgs := []string{"run", "--rm", "-i", "-p", "8080:8080"} //nolint:prealloc // No need to prealloc.
+
 	if os.Getenv("CI") != "" {
 		hostname, err := os.Hostname()
 		if err != nil {
@@ -48,8 +53,9 @@ func runCrocochrome(t *testing.T) {
 
 	dockerArgs = append(dockerArgs, crocochromeImage)
 
-	dockerCmd := exec.Command("docker", dockerArgs...)
+	dockerCmd := exec.CommandContext(t.Context(), "docker", dockerArgs...)
 	dockerCmd.Stderr = os.Stderr
+
 	err = dockerCmd.Start()
 	if err != nil {
 		t.Fatalf("starting crocochrome container: %v", err)
@@ -69,11 +75,15 @@ func runCrocochrome(t *testing.T) {
 	// Wait until crocochrome is reachable.
 	readinessCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
 	for {
-		req, err := http.NewRequestWithContext(readinessCtx, http.MethodGet, readinessEndpoint, nil)
+		req, err := http.NewRequestWithContext(
+			readinessCtx, http.MethodGet, readinessEndpoint, http.NoBody,
+		)
 		if err != nil {
 			t.Fatalf("building crocochrome health request: %v", err)
 		}
+
 		resp, err := http.DefaultClient.Do(req)
 		if resp != nil {
 			resp.Body.Close()
@@ -81,6 +91,7 @@ func runCrocochrome(t *testing.T) {
 
 		if err == nil && resp.StatusCode == http.StatusOK {
 			t.Logf("Crocochrome up and running")
+
 			return
 		}
 
@@ -99,7 +110,7 @@ func runCrocochrome(t *testing.T) {
 
 // runBrowserScript wraps runScript, creating a crocochrome session before running k6 and passing the right WS url to
 // it. The session is deleted when k6 returns.
-func runBrowserScript(t *testing.T, scriptFileName string, env []string) []*prometheus.MetricFamily {
+func runBrowserScript(t *testing.T, scriptFileName string, env []string) []*dto.MetricFamily {
 	t.Helper()
 
 	endpoint := "http://localhost:8080"
@@ -117,6 +128,7 @@ func runBrowserScript(t *testing.T, scriptFileName string, env []string) []*prom
 	}()
 
 	env = append(env, "K6_BROWSER_WS_URL="+session.ChromiumVersion.WebSocketDebuggerURL)
+
 	return runScript(t, scriptFileName, env)
 }
 
@@ -129,22 +141,25 @@ type sessionInfo struct {
 
 // createSession uses the crocochrome API to start a browser session.
 func createSession(endpoint string) (*sessionInfo, error) {
-	resp, err := http.Post(endpoint+"/sessions", "application/json", nil)
+	resp, err := http.Post(endpoint+"/sessions", "application/json", nil) //nolint:noctx // Test helper.
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("posting session: %w", err)
 	}
 
-	defer resp.Body.Close() //nolint:errcheck // Skipping for brevity in test context.
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+
+		//nolint:err113 // No need for static error in test helper.
 		return nil, fmt.Errorf("got unexpected status %d:\n%s", resp.StatusCode, string(body))
 	}
 
 	session := sessionInfo{}
+
 	err = json.NewDecoder(resp.Body).Decode(&session)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decoding session: %w", err)
 	}
 
 	return &session, nil
@@ -152,20 +167,24 @@ func createSession(endpoint string) (*sessionInfo, error) {
 
 // deleteSession calls the crocochrome API to delete a session.
 func deleteSession(endpoint, sessionID string) error {
-	req, err := http.NewRequest(http.MethodDelete, endpoint+"/sessions/"+sessionID, nil)
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodDelete, endpoint+"/sessions/"+sessionID, http.NoBody,
+	)
 	if err != nil {
-		return err
+		return fmt.Errorf("building delete request: %w", err)
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("executing delete request: %w", err)
 	}
 
-	defer resp.Body.Close() //nolint:errcheck // Skipping for brevity in test context.
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+
+		//nolint:err113 // No need for static error in test helper.
 		return fmt.Errorf("got unexpected status %d:\n%s", resp.StatusCode, string(body))
 	}
 

--- a/integration/integration_browserutils_test.go
+++ b/integration/integration_browserutils_test.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2026 Grafana Labs.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//go:build integration
-
 package integration_test
 
 import (
@@ -41,7 +39,7 @@ func runCrocochrome(t *testing.T) {
 	readinessEndpoint := "http://localhost:8080/metrics"
 	dockerArgs := []string{"run", "--rm", "-i", "-p", "8080:8080"} //nolint:prealloc // No need to prealloc.
 
-	if os.Getenv("CI") != "" {
+	if os.Getenv("CI") == "true" {
 		hostname, err := os.Hostname()
 		if err != nil {
 			t.Fatalf("getting hostname for container ID: %v", err)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -97,8 +97,6 @@ func runScript(t *testing.T, scriptFileName string, env []string) []*prometheus.
 func TestSMK6(t *testing.T) {
 	t.Parallel()
 
-	t.Skip("Make me work correctly and remove this.")
-
 	mfs := runScript(t, "test-script.js", nil)
 
 	t.Run("wanted metrics are present", func(t *testing.T) {
@@ -409,10 +407,6 @@ func TestSMK6(t *testing.T) {
 
 func TestSMK6Browser(t *testing.T) {
 	t.Parallel()
-
-	// This test fails to run in all the standard ways. Lacking any
-	// documentation, this gets disabled until the situation is fixed.
-	t.Skip("Make me work correctly and remove this.")
 
 	runCrocochrome(t)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Grafana Labs.
+// Copyright (C) 2026 Grafana Labs.
 // SPDX-License-Identifier: AGPL-3.0-only
 
 //go:build integration
@@ -20,21 +20,26 @@ import (
 	"testing"
 	"time"
 
-	prometheus "github.com/prometheus/client_model/go"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 )
 
-func runScript(t *testing.T, scriptFileName string, env []string) []*prometheus.MetricFamily {
+func runScript(t *testing.T, scriptFileName string, env []string) []*dto.MetricFamily {
 	t.Helper()
 
 	smk6 := os.Getenv("TEST_SMK6")
 	if smk6 == "" {
-		smk6 = filepath.Join("..", "dist", runtime.GOOS+"-"+runtime.GOARCH, "sm-k6")
+		smk6 = filepath.Join(
+			"..", "dist", runtime.GOOS+"-"+runtime.GOARCH, "sm-k6",
+		)
 	}
 
-	_, err := os.Stat(smk6)
+	_, err := os.Stat(smk6) //nolint:gosec // Path comes from env or hardcoded relative path.
 	if err != nil {
-		t.Fatalf("sm-k6 binary does not seem to exist, must be compiled before running this test: %v", err)
+		t.Fatalf(
+			"sm-k6 binary does not seem to exist, must be compiled before running this test: %v",
+			err,
+		)
 	}
 
 	script, err := os.ReadFile(scriptFileName)
@@ -48,9 +53,14 @@ func runScript(t *testing.T, scriptFileName string, env []string) []*prometheus.
 	smOutFile := filepath.Join(t.TempDir(), "metrics.txt")
 	jsonOutFile := filepath.Join(t.TempDir(), "metrics.json")
 
-	cmd := exec.CommandContext(ctx, smk6, "run", "-", "--summary-mode=disabled", "--address=", "-o=sm="+smOutFile, "-o=json="+jsonOutFile)
+	cmd := exec.CommandContext( //nolint:gosec // Path comes from env or hardcoded relative path.
+		ctx, smk6, "run", "-",
+		"--summary-mode=disabled", "--address=",
+		"-o=sm="+smOutFile, "-o=json="+jsonOutFile,
+	)
 	cmd.Stdin = bytes.NewReader(script)
 	cmd.Env = env
+
 	k6out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("running sm-k6: %v\n%s", errors.Join(err, ctx.Err()), string(k6out))
@@ -71,11 +81,15 @@ func runScript(t *testing.T, scriptFileName string, env []string) []*prometheus.
 	t.Logf("sm metrics:\n%s", string(smMetrics))
 	t.Logf("json metrics:\n%s", string(jsonMetrics))
 
-	mfs := []*prometheus.MetricFamily{}
-	decoder := expfmt.NewDecoder(bytes.NewReader(smMetrics), expfmt.NewFormat(expfmt.TypeTextPlain))
+	metricFamilies := make([]*dto.MetricFamily, 0)
+	decoder := expfmt.NewDecoder(
+		bytes.NewReader(smMetrics), expfmt.NewFormat(expfmt.TypeTextPlain),
+	)
+
 	for {
-		mf := &prometheus.MetricFamily{}
-		err := decoder.Decode(mf)
+		metricFamily := &dto.MetricFamily{}
+
+		err := decoder.Decode(metricFamily)
 		if errors.Is(err, io.EOF) {
 			break
 		}
@@ -84,16 +98,17 @@ func runScript(t *testing.T, scriptFileName string, env []string) []*prometheus.
 			t.Fatalf("decoding metric: %v", err)
 		}
 
-		mfs = append(mfs, mf)
+		metricFamilies = append(metricFamilies, metricFamily)
 	}
 
-	if len(mfs) == 0 {
+	if len(metricFamilies) == 0 {
 		t.Fatalf("no metrics decoded")
 	}
 
-	return mfs
+	return metricFamilies
 }
 
+//nolint:gocognit,gocyclo,cyclop // Table-driven test with many subtests.
 func TestSMK6(t *testing.T) {
 	t.Parallel()
 
@@ -124,7 +139,9 @@ func TestSMK6(t *testing.T) {
 		}
 
 		for _, wanted := range wantedMetrics {
-			if !slices.ContainsFunc(mfs, func(m *prometheus.MetricFamily) bool { return *m.Name == wanted }) {
+			if !slices.ContainsFunc(mfs, func(m *dto.MetricFamily) bool {
+				return m.GetName() == wanted
+			}) {
 				t.Fatalf("Metric %q not found in output", wanted)
 			}
 		}
@@ -135,14 +152,24 @@ func TestSMK6(t *testing.T) {
 
 		unwantedMetrics := []string{
 			"probe_checks",
-			"probe_http_reqs", "probe_http_req_failed", // Renamed s/req/requests.
-			"probe_data_sent", "probe_data_received",
-			"probe_http_req_duration", "probe_iteration_duration",
-			"probe_http_req_blocked", "probe_http_req_connecting", "probe_http_req_receiving", "probe_http_req_sending", "probe_http_req_tls_handshaking", "probe_http_req_waiting",
+			"probe_http_reqs",       // Renamed s/req/requests.
+			"probe_http_req_failed", // Renamed s/req/requests.
+			"probe_data_sent",
+			"probe_data_received",
+			"probe_http_req_duration",
+			"probe_iteration_duration",
+			"probe_http_req_blocked",
+			"probe_http_req_connecting",
+			"probe_http_req_receiving",
+			"probe_http_req_sending",
+			"probe_http_req_tls_handshaking",
+			"probe_http_req_waiting",
 		}
 
 		for _, wanted := range unwantedMetrics {
-			if slices.ContainsFunc(mfs, func(m *prometheus.MetricFamily) bool { return *m.Name == wanted }) {
+			if slices.ContainsFunc(mfs, func(m *dto.MetricFamily) bool {
+				return m.GetName() == wanted
+			}) {
 				t.Fatalf("Metric %q not found in output", wanted)
 			}
 		}
@@ -153,20 +180,25 @@ func TestSMK6(t *testing.T) {
 
 		// requiredLabels maps metric names to label names that are required to be present on that metric.
 		requiredLabels := map[string][]string{
-			// FIXME: probe_http_info will not contain these labels if the request failed, so an instance of this metric
-			// fails this test.
-			//"probe_http_info":             {"tls_version", "proto"},
+			// NOTE: probe_http_info will not contain these labels if the
+			// request failed, so an instance of this metric fails this test.
+			// "probe_http_info":             {"tls_version", "proto"},
 			"probe_http_duration_seconds": {"phase"},
 			"probe_checks_total":          {"result"},
 			"my_gauge":                    {"foo", "tab"},
 		}
 
-		for _, mf := range mfs {
-			for _, m := range mf.Metric {
-				requiredLabelsForMetric := requiredLabels[*mf.Name]
-				for _, req := range requiredLabelsForMetric {
-					if !slices.ContainsFunc(m.Label, func(lp *prometheus.LabelPair) bool { return *lp.Name == req }) {
-						t.Fatalf("metric %q does not contain label %q", *mf.Name, req)
+		for _, metricFamily := range mfs {
+			for _, metric := range metricFamily.GetMetric() {
+				required := requiredLabels[metricFamily.GetName()]
+				for _, req := range required {
+					if !slices.ContainsFunc(metric.GetLabel(), func(lp *dto.LabelPair) bool {
+						return lp.GetName() == req
+					}) {
+						t.Fatalf(
+							"metric %q does not contain label %q",
+							metricFamily.GetName(), req,
+						)
 					}
 				}
 			}
@@ -180,6 +212,7 @@ func TestSMK6(t *testing.T) {
 		// The values represent the list of metrics that are _allowed_ to have this label, as an exception.
 		// If a metric contains a label (key), and that metric is not in the list (value), the test fails.
 		type exceptForMetrics []string
+
 		forbiddenLabels := map[string]exceptForMetrics{
 			"error":             {"probe_http_info"},
 			"expected_response": {"probe_http_got_expected_response"},
@@ -187,16 +220,19 @@ func TestSMK6(t *testing.T) {
 			"__raw_url__":       {},
 		}
 
-		for _, mf := range mfs {
-			for _, m := range mf.Metric {
-				for _, labelPair := range m.Label {
-					allowedMetrics, isForbidden := forbiddenLabels[*labelPair.Name]
+		for _, metricFamily := range mfs {
+			for _, metric := range metricFamily.GetMetric() {
+				for _, labelPair := range metric.GetLabel() {
+					allowedMetrics, isForbidden := forbiddenLabels[labelPair.GetName()]
 					if !isForbidden {
 						continue
 					}
 
-					if !slices.Contains(allowedMetrics, *mf.Name) {
-						t.Fatalf("%q should not contain label %q", *mf.Name, *labelPair.Name)
+					if !slices.Contains(allowedMetrics, metricFamily.GetName()) {
+						t.Fatalf(
+							"%q should not contain label %q",
+							metricFamily.GetName(), labelPair.GetName(),
+						)
 					}
 				}
 			}
@@ -213,7 +249,9 @@ func TestSMK6(t *testing.T) {
 			assertValue  func(float64) bool
 		}
 
-		for _, tc := range []testCase{
+		quickpizza := "https://quickpizza.grafana.com"
+
+		for _, testcase := range []testCase{
 			// Some global metrics.
 			{
 				name:        "Script duration seconds",
@@ -245,108 +283,148 @@ func TestSMK6(t *testing.T) {
 			},
 			// Misc http metrics.
 			{
-				name:         "HTTP duration second has a duration-ish value",
-				metricName:   "probe_http_duration_seconds",
-				metricLabels: map[string]string{"phase": "processing", "url": "https://quickpizza.grafana.com/login"},
-				assertValue:  nonZero,
-			},
-			// Custom http phases. Check for each one individually as we use slightly different names than k6 uses.
-			{
-				name:         "HTTP duration seconds has phase=resolve",
-				metricName:   "probe_http_duration_seconds",
-				metricLabels: map[string]string{"phase": "resolve", "url": "https://quickpizza.grafana.com/login"},
-				assertValue:  any, // Just fail if not present.
+				name:       "HTTP duration second has a duration-ish value",
+				metricName: "probe_http_duration_seconds",
+				metricLabels: map[string]string{
+					"phase": "processing",
+					"url":   quickpizza + "/login",
+				},
+				assertValue: nonZero,
 			},
 			{
-				name:         "HTTP duration seconds has phase=connect",
-				metricName:   "probe_http_duration_seconds",
-				metricLabels: map[string]string{"phase": "connect", "url": "https://quickpizza.grafana.com/login"},
-				assertValue:  any, // Just fail if not present.
+				name:       "HTTP duration seconds has phase=resolve",
+				metricName: "probe_http_duration_seconds",
+				metricLabels: map[string]string{
+					"phase": "resolve",
+					"url":   quickpizza + "/login",
+				},
+				assertValue: anyValue,
 			},
 			{
-				name:         "HTTP duration seconds has phase=tls",
-				metricName:   "probe_http_duration_seconds",
-				metricLabels: map[string]string{"phase": "tls", "url": "https://quickpizza.grafana.com/login"},
-				assertValue:  any, // Just fail if not present.
+				name:       "HTTP duration seconds has phase=connect",
+				metricName: "probe_http_duration_seconds",
+				metricLabels: map[string]string{
+					"phase": "connect",
+					"url":   quickpizza + "/login",
+				},
+				assertValue: anyValue,
 			},
 			{
-				name:         "HTTP duration seconds has phase=processing",
-				metricName:   "probe_http_duration_seconds",
-				metricLabels: map[string]string{"phase": "processing", "url": "https://quickpizza.grafana.com/login"},
-				assertValue:  any, // Just fail if not present.
+				name:       "HTTP duration seconds has phase=tls",
+				metricName: "probe_http_duration_seconds",
+				metricLabels: map[string]string{
+					"phase": "tls",
+					"url":   quickpizza + "/login",
+				},
+				assertValue: anyValue,
 			},
 			{
-				name:         "HTTP duration seconds has phase=transfer",
-				metricName:   "probe_http_duration_seconds",
-				metricLabels: map[string]string{"phase": "transfer", "url": "https://quickpizza.grafana.com/login"},
-				assertValue:  any, // Just fail if not present.
+				name:       "HTTP duration seconds has phase=processing",
+				metricName: "probe_http_duration_seconds",
+				metricLabels: map[string]string{
+					"phase": "processing",
+					"url":   quickpizza + "/login",
+				},
+				assertValue: anyValue,
 			},
 			{
-				name:         "Error code for request that should succeed",
-				metricName:   "probe_http_error_code",
-				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/login"},
-				assertValue:  equals(0),
+				name:       "HTTP duration seconds has phase=transfer",
+				metricName: "probe_http_duration_seconds",
+				metricLabels: map[string]string{
+					"phase": "transfer",
+					"url":   quickpizza + "/login",
+				},
+				assertValue: anyValue,
 			},
 			{
-				name:         "Error code for request that should fail",
-				metricName:   "probe_http_error_code",
-				metricLabels: map[string]string{"url": "http://fail.internal/failure-nxdomain"},
-				assertValue:  equals(1101),
+				name:       "Error code for request that should succeed",
+				metricName: "probe_http_error_code",
+				metricLabels: map[string]string{
+					"url": quickpizza + "/login",
+				},
+				assertValue: equals(0),
 			},
 			{
-				name:         "HTTP status code for a request that should succeed",
-				metricName:   "probe_http_status_code",
-				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/login"},
-				assertValue:  equals(200),
+				name:       "Error code for request that should fail",
+				metricName: "probe_http_error_code",
+				metricLabels: map[string]string{
+					"url": "http://fail.internal/failure-nxdomain",
+				},
+				assertValue: equals(1101),
 			},
 			{
-				name:         "Expected response for a request that should succeed",
-				metricName:   "probe_http_got_expected_response",
-				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/login"},
-				assertValue:  equals(1),
+				name:       "HTTP status code for a request that should succeed",
+				metricName: "probe_http_status_code",
+				metricLabels: map[string]string{
+					"url": quickpizza + "/login",
+				},
+				assertValue: equals(200),
 			},
 			{
-				name:         "Expected response for a request that should fail",
-				metricName:   "probe_http_got_expected_response",
-				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/thats-a-404"},
-				assertValue:  equals(0),
+				name:       "Expected response for a request that should succeed",
+				metricName: "probe_http_got_expected_response",
+				metricLabels: map[string]string{
+					"url": quickpizza + "/login",
+				},
+				assertValue: equals(1),
 			},
 			{
-				name:         "Total requests for a URL accessed once",
-				metricName:   "probe_http_requests_total",
-				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/login"},
-				assertValue:  equals(1),
+				name:       "Expected response for a request that should fail",
+				metricName: "probe_http_got_expected_response",
+				metricLabels: map[string]string{
+					"url": quickpizza + "/thats-a-404",
+				},
+				assertValue: equals(0),
 			},
 			{
-				name:         "Total requests for a URL accessed twice",
-				metricName:   "probe_http_requests_total",
-				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/thats-another-404-accessed-twice"},
-				assertValue:  equals(2),
+				name:       "Total requests for a URL accessed once",
+				metricName: "probe_http_requests_total",
+				metricLabels: map[string]string{
+					"url": quickpizza + "/login",
+				},
+				assertValue: equals(1),
 			},
 			{
-				name:         "HTTP requests failed rate",
-				metricName:   "probe_http_requests_failed",
-				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/thats-another-404-accessed-twice"},
-				assertValue:  equals(1),
+				name:       "Total requests for a URL accessed twice",
+				metricName: "probe_http_requests_total",
+				metricLabels: map[string]string{
+					"url": quickpizza + "/thats-another-404-accessed-twice",
+				},
+				assertValue: equals(2),
 			},
 			{
-				name:         "HTTP requests failed total",
-				metricName:   "probe_http_requests_failed_total",
-				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/thats-another-404-accessed-twice"},
-				assertValue:  equals(2),
+				name:       "HTTP requests failed rate",
+				metricName: "probe_http_requests_failed",
+				metricLabels: map[string]string{
+					"url": quickpizza + "/thats-another-404-accessed-twice",
+				},
+				assertValue: equals(1),
 			},
 			{
-				name:         "HTTP version",
-				metricName:   "probe_http_version",
-				metricLabels: map[string]string{"url": "https://quickpizza.grafana.com/login"},
-				assertValue:  func(f float64) bool { return f >= 1.1 },
+				name:       "HTTP requests failed total",
+				metricName: "probe_http_requests_failed_total",
+				metricLabels: map[string]string{
+					"url": quickpizza + "/thats-another-404-accessed-twice",
+				},
+				assertValue: equals(2),
+			},
+			{
+				name:       "HTTP version",
+				metricName: "probe_http_version",
+				metricLabels: map[string]string{
+					"url": quickpizza + "/login",
+				},
+				assertValue: func(f float64) bool { return f >= 1.1 },
 			},
 			{
 				name:       "TLS version label value",
 				metricName: "probe_http_info",
-				// Test for a paticular URL to avoid matching a failed request, which has no TLS version.
-				metricLabels: map[string]string{"tls_version": "1.3", "url": "https://quickpizza.grafana.com/login"},
-				assertValue:  any, // Just fail if not present.
+				// Test for a particular URL to avoid matching a failed request, which has no TLS version.
+				metricLabels: map[string]string{
+					"tls_version": "1.3",
+					"url":         quickpizza + "/login",
+				},
+				assertValue: anyValue,
 			},
 			{
 				name:         "__raw_url__ overrides url",
@@ -355,40 +433,52 @@ func TestSMK6(t *testing.T) {
 				assertValue:  equals(1),
 			},
 		} {
-			tc := tc
-			t.Run(tc.name, func(t *testing.T) {
+			t.Run(testcase.name, func(t *testing.T) {
 				t.Parallel()
 
 				matchedMetrics := 0
-				for _, mf := range mfs {
-					if *mf.Name != tc.metricName {
-						// This is not the metric we are asserting on
+
+				for _, metricFamily := range mfs {
+					if metricFamily.GetName() != testcase.metricName {
+						// This is not the metric we are asserting on, skip it.
 						continue
 					}
 
 				metric:
-					for _, m := range mf.Metric {
-						for _, labelPair := range m.Label {
+					for _, metric := range metricFamily.GetMetric() {
+						for _, labelPair := range metric.GetLabel() {
 							// Check each label of this particular metric against the test case labels.
 							// If the metric has a label we're not matching for, that's okay, but it we are matching
 							// it then the value should match as well.
-							if actual, present := tc.metricLabels[*labelPair.Name]; present && actual != *labelPair.Value {
+							actual, present := testcase.metricLabels[labelPair.GetName()]
+							if present && actual != labelPair.GetValue() {
 								continue metric
 							}
 						}
 
 						matchedMetrics++
-						// Hack. Instead of check which type this metric has, and then use that one, rely on GetValue
-						// that does this check for us and return 0 if the type is not correct.
-						metricValue := m.Gauge.GetValue() + m.Counter.GetValue() + m.Untyped.GetValue()
-						if !tc.assertValue(metricValue) {
-							t.Fatalf("Metric value for %q got unexpected value %v (did not satisfy assert function)", *mf.Name, metricValue)
+						// Instead of check which type this metric has, and then use that one, rely on
+						// GetValue() that does this check for us and return 0 if the type is not correct.
+						metricValue := metric.GetGauge().GetValue() +
+							metric.GetCounter().GetValue() +
+							metric.GetUntyped().GetValue()
+
+						if !testcase.assertValue(metricValue) {
+							t.Fatalf(
+								"Metric value for %q got unexpected value %v "+
+									"(did not satisfy assert function)",
+								metricFamily.GetName(), metricValue,
+							)
 						}
 					}
 				}
 
 				if matchedMetrics == 0 {
-					t.Fatalf("Test case for %q with specified labels matched no metric in extension output", tc.metricName)
+					t.Fatalf(
+						"Test case for %q with specified labels "+
+							"matched no metric in extension output",
+						testcase.metricName,
+					)
 				}
 			})
 		}
@@ -397,14 +487,15 @@ func TestSMK6(t *testing.T) {
 	t.Run("metrics have required prefix", func(t *testing.T) {
 		t.Parallel()
 
-		for _, m := range mfs {
-			if !strings.HasPrefix(*m.Name, "probe_") {
-				t.Fatalf("Metric %q not have the required prefix", *m.Name)
+		for _, metricFamily := range mfs {
+			if !strings.HasPrefix(metricFamily.GetName(), "probe_") {
+				t.Fatalf("Metric %q not have the required prefix", metricFamily.GetName())
 			}
 		}
 	})
 }
 
+//nolint:gocognit,cyclop // Table-driven test with many subtests.
 func TestSMK6Browser(t *testing.T) {
 	t.Parallel()
 
@@ -412,7 +503,6 @@ func TestSMK6Browser(t *testing.T) {
 
 	t.Run("default settings", func(t *testing.T) {
 		// Do not run this one in parallel, as crocochrome only supports one concurrent script run.
-
 		mfs := runBrowserScript(t, "browser-script.js", nil) // Default allowlist.
 
 		t.Run("includes expected metrics", func(t *testing.T) {
@@ -428,12 +518,13 @@ func TestSMK6Browser(t *testing.T) {
 				"probe_browser_web_vital_lcp",
 				"probe_browser_web_vital_ttfb",
 			}
-			for _, w := range wanted {
-				if !slices.ContainsFunc(mfs, func(mf *prometheus.MetricFamily) bool {
-					return *mf.Name == w
+
+			for _, wantedName := range wanted {
+				if !slices.ContainsFunc(mfs, func(metricFamily *dto.MetricFamily) bool {
+					return metricFamily.GetName() == wantedName
 				}) {
 					t.Log(mfs)
-					t.Fatalf("Missing metric %q", w)
+					t.Fatalf("Missing metric %q", wantedName)
 				}
 			}
 		})
@@ -441,11 +532,17 @@ func TestSMK6Browser(t *testing.T) {
 		t.Run("only includes document browser metrics", func(t *testing.T) {
 			t.Parallel()
 
-			for _, mf := range mfs {
-				for _, m := range mf.Metric {
-					for _, lp := range m.Label {
-						if *lp.Name == "resource_type" && *lp.Value != "Document" {
-							t.Fatalf("metric %q should not have %s=%q", *mf.Name, *lp.Name, *lp.Value)
+			for _, metricFamily := range mfs {
+				for _, metric := range metricFamily.GetMetric() {
+					for _, labelPair := range metric.GetLabel() {
+						if labelPair.GetName() == "resource_type" &&
+							labelPair.GetValue() != "Document" {
+							t.Fatalf(
+								"metric %q should not have %s=%q",
+								metricFamily.GetName(),
+								labelPair.GetName(),
+								labelPair.GetValue(),
+							)
 						}
 					}
 				}
@@ -455,10 +552,13 @@ func TestSMK6Browser(t *testing.T) {
 		t.Run("number of timeseries is sane", func(t *testing.T) {
 			t.Parallel()
 
-			for _, mf := range mfs {
+			for _, metricFamily := range mfs {
 				sane := 5
-				if found := len(mf.Metric); found > sane {
-					t.Fatalf("Found suspicioulsy large number of timeseries (%d>%d) for metric %q", found, sane, *mf.Name)
+				if found := len(metricFamily.GetMetric()); found > sane {
+					t.Fatalf(
+						"Found suspiciously large number of timeseries (%d>%d) for metric %q",
+						found, sane, metricFamily.GetName(),
+					)
 				}
 			}
 		})
@@ -468,17 +568,27 @@ func TestSMK6Browser(t *testing.T) {
 		// Do not run this one in parallel, as crocochrome only supports one concurrent script run.
 
 		// Custom allowlist, mixed case.
-		mfs := runBrowserScript(t, "browser-script.js", []string{"SM_K6_BROWSER_RESOURCE_TYPES=image,script"})
+		mfs := runBrowserScript(
+			t, "browser-script.js",
+			[]string{"SM_K6_BROWSER_RESOURCE_TYPES=image,script"},
+		)
 
 		t.Run("only includes expected browser metrics", func(t *testing.T) {
 			t.Parallel()
 
 			expected := []string{"Image", "Script"}
-			for _, mf := range mfs {
-				for _, m := range mf.Metric {
-					for _, lp := range m.Label {
-						if *lp.Name == "resource_type" && !slices.Contains(expected, *lp.Value) {
-							t.Fatalf("metric %q should not have %s=%q", *mf.Name, *lp.Name, *lp.Value)
+
+			for _, metricFamily := range mfs {
+				for _, metric := range metricFamily.GetMetric() {
+					for _, labelPair := range metric.GetLabel() {
+						if labelPair.GetName() == "resource_type" &&
+							!slices.Contains(expected, labelPair.GetValue()) {
+							t.Fatalf(
+								"metric %q should not have %s=%q",
+								metricFamily.GetName(),
+								labelPair.GetName(),
+								labelPair.GetValue(),
+							)
 						}
 					}
 				}
@@ -488,16 +598,19 @@ func TestSMK6Browser(t *testing.T) {
 
 	t.Run("allow all the things", func(t *testing.T) {
 		// Do not run this one in parallel, as crocochrome only supports one concurrent script run.
-
-		mfs := runBrowserScript(t, "browser-script.js", []string{"SM_K6_BROWSER_RESOURCE_TYPES=*"}) // All The Things!
+		mfs := runBrowserScript(
+			t, "browser-script.js",
+			[]string{"SM_K6_BROWSER_RESOURCE_TYPES=*"},
+		)
 
 		t.Run("only includes expected browser metrics", func(t *testing.T) {
 			t.Parallel()
 
-			for _, mf := range mfs {
-				for _, m := range mf.Metric {
-					for _, lp := range m.Label {
-						if *lp.Name == "resource_type" && *lp.Value == "Script" {
+			for _, metricFamily := range mfs {
+				for _, metric := range metricFamily.GetMetric() {
+					for _, labelPair := range metric.GetLabel() {
+						if labelPair.GetName() == "resource_type" &&
+							labelPair.GetValue() == "Script" {
 							// We found a metric with resource_type=Script, which is not in the default allowlist.
 							// Approximating this as the wildcard working, and calling the test good.
 							return
@@ -521,6 +634,6 @@ func nonZero(v float64) bool {
 	return v > 0
 }
 
-func any(float64) bool {
+func anyValue(float64) bool {
 	return true
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -48,7 +48,7 @@ func runScript(t *testing.T, scriptFileName string, env []string) []*prometheus.
 	smOutFile := filepath.Join(t.TempDir(), "metrics.txt")
 	jsonOutFile := filepath.Join(t.TempDir(), "metrics.json")
 
-	cmd := exec.CommandContext(ctx, smk6, "run", "-", "-o=sm="+smOutFile, "-o=json="+jsonOutFile)
+	cmd := exec.CommandContext(ctx, smk6, "run", "-", "--summary-mode=disabled", "--address=", "-o=sm="+smOutFile, "-o=json="+jsonOutFile)
 	cmd.Stdin = bytes.NewReader(script)
 	cmd.Env = env
 	k6out, err := cmd.CombinedOutput()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2026 Grafana Labs.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//go:build integration
-
 package integration_test
 
 import (
@@ -111,6 +109,10 @@ func runScript(t *testing.T, scriptFileName string, env []string) []*dto.MetricF
 //nolint:gocognit,gocyclo,cyclop // Table-driven test with many subtests.
 func TestSMK6(t *testing.T) {
 	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
 
 	mfs := runScript(t, "test-script.js", nil)
 
@@ -495,9 +497,13 @@ func TestSMK6(t *testing.T) {
 	})
 }
 
-//nolint:gocognit,cyclop // Table-driven test with many subtests.
+//nolint:gocognit,gocyclo,cyclop // Table-driven test with many subtests.
 func TestSMK6Browser(t *testing.T) {
 	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
 
 	runCrocochrome(t)
 

--- a/integration/test-script.js
+++ b/integration/test-script.js
@@ -37,7 +37,6 @@ export default function () {
     }
   );
 
-  http.get(`http://${testHost}/login`); // non-https.
   http.get(`https://${testHost}/login`);
   http.get(`https://${testHost}/thats-a-404`); // 404
   http.get(`https://${testHost}/thats-another-404-accessed-twice`); // 404

--- a/scripts/docker-run
+++ b/scripts/docker-run
@@ -35,6 +35,16 @@ if test -z "${GOARCH}" ; then
 	GOARCH=$(go env GOARCH)
 fi
 
+default_docker_sock=/var/run/docker.sock
+if test -z "${DOCKER_SOCK}" ; then
+  DOCKER_SOCK=${default_docker_sock}
+fi
+
+group=$(id -g)
+if grep -qe 'docker' /etc/group; then
+  group=$(grep -e docker /etc/group | cut -d: -f 3)
+fi
+
 tty_flag=""
 int_flag=""
 if test -t 1 ; then
@@ -46,11 +56,13 @@ exec docker run                                  \
 	$tty_flag                                \
 	$int_flag                                \
 	--rm                                     \
-	--user "$(id -u):$(id -g)"               \
+	--user "$(id -u):${group}"               \
 	--volume "${ROOTDIR}:${ROOTDIR}"         \
 	--volume "${HOME}/.cache:/.cache"        \
 	--volume "${GOPATH}:/go"                 \
 	--volume "${GOMODCACHE}:/go/pkg/mod"     \
+	--volume "${DOCKER_SOCK}:${default_docker_sock}"     \
+	--network=host                           \
 	--workdir "${PWD}"                       \
 	--env CI="${CI}"                         \
 	--env CGO_ENABLED="${CGO_ENABLED}"       \

--- a/scripts/make/400_testing.mk
+++ b/scripts/make/400_testing.mk
@@ -6,15 +6,33 @@ TEST_OUTPUT := $(DISTDIR)/test
 
 ifeq ($(CI),true)
 GOTESTSUM ?= gotestsum
-GO_TEST_BUILD_TAGS ?= -tags=integration
 endif
 
 ifeq ($(origin GOTESTSUM),undefined)
 GOTESTSUM ?= ./scripts/docker-run gotestsum
 endif
 
+# CI runs default to running all tests.
+TEST_SHORT ?= $(if $(filter $(CI),true),false,true)
+
+# If TEST_SHORT is set to true, we run only short tests.
+ifeq ($(strip $(TEST_SHORT)),true)
+TEST_SHORT_ARG := -short
+else
+TEST_SHORT_ARG :=
+endif
+
+# In CI we never depend on `build-native` as that as already been done. If we
+# are running only short tests, do not pass `build-native` as a dependency to
+# speed things up.
+ifeq ($(or $(filter $(CI),true), $(filter $(TEST_SHORT),true)),true)
+EXTRA_TEST_DEPS :=
+else
+EXTRA_TEST_DEPS := build-native
+endif
+
 .PHONY: test-go
-test-go: build-native
+test-go: $(EXTRA_TEST_DEPS)
 test-go: ## Run Go tests.
 	$(S) echo "test backend"
 	$(S) mkdir -p '$(DISTDIR)'
@@ -28,7 +46,7 @@ test-go: ## Run Go tests.
 		-cover \
 		-coverprofile=$(TEST_OUTPUT).cov \
 		-race \
-		$(GO_TEST_BUILD_TAGS) \
+		$(TEST_SHORT_ARG) \
 		$(GO_TEST_ARGS)
 	$(S) $(ROOTDIR)/scripts/report-test-coverage $(TEST_OUTPUT).cov
 

--- a/scripts/make/400_testing.mk
+++ b/scripts/make/400_testing.mk
@@ -15,6 +15,7 @@ endif
 
 .PHONY: test-go
 test-go: export CGO_ENABLED=1 # Required so that -race works.
+test-go: build-native
 test-go: ## Run Go tests.
 	$(S) echo "test backend"
 	$(S) mkdir -p '$(DISTDIR)'

--- a/scripts/make/400_testing.mk
+++ b/scripts/make/400_testing.mk
@@ -14,12 +14,12 @@ GOTESTSUM ?= ./scripts/docker-run gotestsum
 endif
 
 .PHONY: test-go
-test-go: export CGO_ENABLED=1 # Required so that -race works.
 test-go: build-native
 test-go: ## Run Go tests.
 	$(S) echo "test backend"
 	$(S) mkdir -p '$(DISTDIR)'
-	$(GOTESTSUM) \
+	# CGO_ENABLED is required for -race
+	CGO_ENABLED=1 $(GOTESTSUM) \
 		--format standard-verbose \
 		--jsonfile $(TEST_OUTPUT).json \
 		--junitfile $(TEST_OUTPUT).xml \


### PR DESCRIPTION
This PR grafts the test suite into the changes made by https://github.com/grafana/xk6-sm/pull/170.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Re-enables integration tests and changes how they run in CI/Docker, which can affect pipeline stability and developer workflows. Core production code is untouched, but test harness and Docker networking/user changes may be environment-sensitive.
> 
> **Overview**
> Restores the integration test suite by removing the permanent skips and making integration tests run by default in CI while remaining opt-in locally via `TEST_SHORT=false`/`-short` behavior.
> 
> Hardens the integration harness: `runCrocochrome` now pre-pulls the image, adjusts Docker networking for CI (`--network=container:<job>`), and improves HTTP request handling/error wrapping; `runScript` disables k6 summary output and stabilizes metric decoding/assertions.
> 
> Updates the test runner tooling to support the above: `scripts/docker-run` mounts the Docker socket and uses host networking (with docker group handling), the Makefile test target adds `TEST_SHORT` toggles and avoids unnecessary `build-native`, and the README documents how to run unit vs full (Docker) tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ed99c973bb5923023f9110e636f13c20fd1a00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->