### PR TITLE
fix: do not abort metric processing entirely on parsing error

### DIFF
--- a/output.go
+++ b/output.go
@@ -269,14 +269,20 @@ func (ms *metricStore) DeriveMetrics() {
 			}
 
 			{
-				strCode, _ := ts.tags.Get("proto")
-				strCode = strings.ToLower(strCode)
+				proto, hasProto := ts.tags.Get("proto")
+				if !hasProto {
+					continue
+				}
+
+				strCode := strings.ToLower(proto)
 				strCode = strings.TrimPrefix(strCode, "http/") // Leave bare version for "HTTP/1.1"
 				strCode = strings.TrimPrefix(strCode, "h")     // Leave bare version for "h2"
 
 				newValue, err := strconv.ParseFloat(strCode, 32)
 				if err != nil {
-					return // Invalid protocol, skip timeseries.
+					ms.logger.Warnf("could not parse http proto %q: %v", proto, err)
+
+					continue // Invalid protocol, skip timeseries.
 				}
 
 				httpVersionTS := timeseries{


### PR DESCRIPTION
Additionally, log that parsing error

Tested using https://github.com/grafana/xk6-sm/pull/217, extacted to a different PR for easier reviewability.