### PR TITLE
chore: Update ghcr.io/grafana/grafana-build-tools Docker tag to v1.37.1

### DIFF
--- a/.gbt.mk
+++ b/.gbt.mk
@@ -4,4 +4,4 @@
 # and a shell script. This is achieved by using the `VAR=value` syntax, which
 # is valid in both Makefile and shell.
 
-GBT_IMAGE=ghcr.io/grafana/grafana-build-tools:v1.37.0
+GBT_IMAGE=ghcr.io/grafana/grafana-build-tools:v1.37.1

--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -25,7 +25,7 @@ jobs:
       contents: read
       id-token: write
     container:
-      image: ghcr.io/grafana/grafana-build-tools:v1.37.0@sha256:9258344db88ac23f4cfc7fee201a6c2c4f3ac72e056a5a6543fbae611807266c
+      image: ghcr.io/grafana/grafana-build-tools:v1.37.1@sha256:25ec2e6091e13299e52382b62fab44d3103e1b5949e655aa41b60099caee391e
       volumes:
         # This works as long as we are using self-hosted runners.
         #


### PR DESCRIPTION
Includes [xk6 v1.4.0](https://github.com/grafana/xk6/releases/tag/v1.4.0) which adds support for k6 v2.
Related grafana/grafana-build-tools/pull/579

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the pinned build container used in CI and local build tooling, which can affect dependency resolution and build/test behavior across architectures.
> 
> **Overview**
> Updates the pinned `ghcr.io/grafana/grafana-build-tools` image from `v1.37.0` to `v1.37.1` for both local tooling (`.gbt.mk`) and the PR validation workflow container (including the new image digest).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b964d8b41cb3e56502ef0a691715bd899d27f91e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->