### PR TITLE
fix: Add retries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 toolchain go1.25.5
 
 require (
+	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/grafana/gsm-api-go-client v0.3.0
 	github.com/mstoykov/atlas v0.0.0-20220811071828-388f114305dd
 	github.com/prometheus/client_model v0.6.2
@@ -19,7 +20,6 @@ require (
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
-	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect

--- a/internal/secrets/secret.go
+++ b/internal/secrets/secret.go
@@ -10,9 +10,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	gsmClient "github.com/grafana/gsm-api-go-client"
 	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/secretsource"
@@ -26,6 +28,29 @@ var (
 	errFailedToGetSecret             = errors.New("failed to get secret")
 	errInvalidRequestsPerMinuteLimit = errors.New("requestsPerMinuteLimit must be greater than 0")
 	errInvalidRequestsBurst          = errors.New("requestsBurst must be greater than 0")
+	errTooManyRetries                = errors.New("too many retries")
+)
+
+// retryError signals to the retry loop that the operation should be
+// retried, while carrying the terminal HTTP status. When retries are
+// exhausted, the status surfaces in the wrapped errTooManyRetries
+// returned to the caller.
+type retryError struct {
+	status string
+}
+
+func (e *retryError) Error() string {
+	return "retry request: " + e.status
+}
+
+const (
+	maxAttempts         = 5
+	baseInterval        = 100 * time.Millisecond
+	requestTimeout      = 2 * time.Second
+	maxInterval         = 1 * time.Second
+	maxElapsedTime      = maxAttempts * requestTimeout
+	backoffMultiplier   = 2.5
+	randomizationFactor = 0.10
 )
 
 // extConfig holds the configuration for Grafana Secrets.
@@ -105,7 +130,9 @@ func (gs *grafanaSecrets) Description() string {
 }
 
 func (gs *grafanaSecrets) Get(key string) (string, error) {
-	gs.logger.WithField("key", key).Debug("Getting secret")
+	logger := gs.logger.WithField("key", key)
+
+	logger.Debug("Getting secret")
 
 	ctx := context.Background()
 
@@ -113,29 +140,98 @@ func (gs *grafanaSecrets) Get(key string) (string, error) {
 		return "", fmt.Errorf("rate limiter error: %w", err)
 	}
 
-	response, err := gs.client.DecryptSecretById(ctx, key)
-	if err != nil {
-		gs.logger.WithError(err).Debug("error getting secret")
+	var (
+		retryAfterError *backoff.RetryAfterError
+		retryErr        *retryError
+		requests        int
+	)
 
-		return "", fmt.Errorf("failed to get secret: %w", err)
+	plaintext, err := retry(ctx, gs.get(ctx, key, logger, &requests))
+	switch {
+	case err == nil:
+		if requests > 1 {
+			logger.WithField("requests", requests).Info("secret retrieved")
+		}
+
+		return plaintext, nil
+
+	case errors.As(err, &retryErr):
+		// If this error gets back here it's because we retried too many times.
+		logger.WithError(err).WithField("requests", requests).Error("too many retries getting secret")
+
+		return "", fmt.Errorf("%w (last status: %s)", errTooManyRetries, retryErr.status)
+
+	case errors.As(err, &retryAfterError):
+		// The server asked us to wait longer than our total retry budget.
+		logger.WithError(err).WithField("requests", requests).Warn("Retry-After exceeds retry budget")
+
+		return "", errTooManyRetries
+
+	default:
+		logger.WithError(err).WithField("requests", requests).Error("error getting secret")
+
+		return "", err
 	}
+}
 
-	defer response.Body.Close()
+func (gs *grafanaSecrets) get(
+	ctx context.Context,
+	key string,
+	logger logrus.FieldLogger,
+	counter *int,
+) func() (string, error) {
+	return func() (string, error) {
+		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+		defer cancel()
 
-	if response.StatusCode != http.StatusOK {
-		gs.logger.WithField("status", response.Status).Debug("failed to get secret")
+		*counter++
 
-		return "", fmt.Errorf("status code %d: %w", response.StatusCode, errFailedToGetSecret)
+		response, err := gs.client.DecryptSecretById(reqCtx, key)
+		if err != nil {
+			// Non-permanent error from the transport; backoff.Retry treats
+			// it as retriable.
+			logger.WithError(err).Debug("error getting secret")
+
+			return "", fmt.Errorf("failed to get secret: %w", err)
+		}
+
+		defer response.Body.Close()
+
+		switch response.StatusCode {
+		case http.StatusOK:
+			var decryptedSecret gsmClient.DecryptedSecret
+
+			err := json.NewDecoder(response.Body).Decode(&decryptedSecret)
+			if err != nil {
+				logger.WithError(err).Error("error decoding secret")
+
+				return "", backoff.Permanent(fmt.Errorf("failed to decode response: %w", err))
+			}
+
+			return decryptedSecret.Plaintext, nil
+
+		case http.StatusTooManyRequests:
+			if retryErr := parseRetryAfter(response.Header.Get("Retry-After")); retryErr != nil {
+				return "", retryErr
+			}
+
+			fallthrough
+
+		case http.StatusRequestTimeout,
+			http.StatusConflict,
+			http.StatusInternalServerError,
+			http.StatusBadGateway,
+			http.StatusServiceUnavailable,
+			http.StatusGatewayTimeout:
+			logger.WithField("status", response.Status).Warn("Retriable error received")
+
+			return "", &retryError{status: response.Status}
+
+		default:
+			// Anything else we don't know how to handle and therefore we won't retry it.
+			return "", backoff.Permanent(fmt.Errorf("status code %d: %w", response.StatusCode, errFailedToGetSecret))
+		}
 	}
-
-	var decryptedSecret gsmClient.DecryptedSecret
-	if err := json.NewDecoder(response.Body).Decode(&decryptedSecret); err != nil {
-		gs.logger.WithError(err).Debug("error decoding secret")
-
-		return "", fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	return decryptedSecret.Plaintext, nil
 }
 
 type limiter interface {
@@ -198,4 +294,49 @@ func getConfig(arg string) (extConfig, error) {
 	}
 
 	return config, nil
+}
+
+// parseRetryAfter interprets a Retry-After header value in either form
+// allowed by RFC 7231 §7.1.3: a non-negative integer (seconds) or an
+// HTTP-date. It returns a backoff error carrying the requested wait, or
+// nil if the value is empty or unparseable (in which case the caller
+// should fall back to its own backoff schedule).
+func parseRetryAfter(value string) error {
+	if value == "" {
+		return nil
+	}
+
+	if seconds, err := strconv.Atoi(value); err == nil {
+		//nolint:wrapcheck // Sentinel returned for backoff.Retry to consume.
+		return backoff.RetryAfter(seconds)
+	}
+
+	if deadline, err := http.ParseTime(value); err == nil {
+		return &backoff.RetryAfterError{Duration: max(0, time.Until(deadline))}
+	}
+
+	return nil
+}
+
+// retry executes the provided function until it succeeds or the maximum number of attempts is reached.
+func retry(ctx context.Context, operation func() (string, error)) (string, error) {
+	// Since baseInterval should be much lower than maxInterval, only the
+	// last few retries will wait for MaxInterval if any. If all the
+	// requests are hitting the timeout, more retries is not going to
+	// change that.
+	expbackoff := backoff.ExponentialBackOff{
+		InitialInterval:     baseInterval,
+		MaxInterval:         maxInterval,
+		Multiplier:          backoffMultiplier,
+		RandomizationFactor: randomizationFactor,
+	}
+
+	//nolint:wrapcheck // This is returning our own error from operation.
+	return backoff.Retry(
+		ctx,
+		operation,
+		backoff.WithBackOff(&expbackoff),
+		backoff.WithMaxTries(maxAttempts),
+		backoff.WithMaxElapsedTime(maxElapsedTime),
+	)
 }

--- a/internal/secrets/secret.go
+++ b/internal/secrets/secret.go
@@ -149,9 +149,7 @@ func (gs *grafanaSecrets) Get(key string) (string, error) {
 	plaintext, err := retry(ctx, gs.get(ctx, key, logger, &requests))
 	switch {
 	case err == nil:
-		if requests > 1 {
-			logger.WithField("requests", requests).Info("secret retrieved")
-		}
+		logger.WithField("attempts", requests).Info("secret retrieved")
 
 		return plaintext, nil
 

--- a/internal/secrets/secret.go
+++ b/internal/secrets/secret.go
@@ -143,30 +143,32 @@ func (gs *grafanaSecrets) Get(key string) (string, error) {
 	var (
 		retryAfterError *backoff.RetryAfterError
 		retryErr        *retryError
-		requests        int
+		attempts        int
 	)
 
-	plaintext, err := retry(ctx, gs.get(ctx, key, logger, &requests))
+	plaintext, err := retry(ctx, gs.get(ctx, key, logger, &attempts))
+	logger = logger.WithField("attempts", attempts)
+
 	switch {
 	case err == nil:
-		logger.WithField("attempts", requests).Info("secret retrieved")
+		logger.Info("secret retrieved")
 
 		return plaintext, nil
 
 	case errors.As(err, &retryErr):
 		// If this error gets back here it's because we retried too many times.
-		logger.WithError(err).WithField("requests", requests).Error("too many retries getting secret")
+		logger.WithError(err).Error("too many retries getting secret")
 
 		return "", fmt.Errorf("%w (last status: %s)", errTooManyRetries, retryErr.status)
 
 	case errors.As(err, &retryAfterError):
 		// The server asked us to wait longer than our total retry budget.
-		logger.WithError(err).WithField("requests", requests).Warn("Retry-After exceeds retry budget")
+		logger.WithError(err).Warn("Retry-After exceeds retry budget")
 
 		return "", errTooManyRetries
 
 	default:
-		logger.WithError(err).WithField("requests", requests).Error("error getting secret")
+		logger.WithError(err).Error("error getting secret")
 
 		return "", err
 	}

--- a/internal/secrets/secret_test.go
+++ b/internal/secrets/secret_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -360,6 +361,227 @@ func TestGetConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGrafanaSecretsGetRetry(t *testing.T) {
+	t.Parallel()
+
+	const (
+		secretName  = "test-secret-id"
+		secretValue = "test-secret-value"
+		testToken   = "test-token"
+	)
+
+	makeClient := func(serverURL string) *gsmClient.Client {
+		c, _ := gsmClient.NewClient(serverURL, gsmClient.WithBearerAuth(testToken))
+
+		return c
+	}
+
+	makeServer := func(handler http.HandlerFunc) *httptest.Server {
+		return httptest.NewServer(handler)
+	}
+
+	okResponse := func(t *testing.T, w http.ResponseWriter) {
+		t.Helper()
+		w.Header().Set("Content-Type", "application/json")
+
+		if err := json.NewEncoder(w).Encode(gsmClient.DecryptedSecret{Plaintext: secretValue}); err != nil {
+			t.Fatalf("failed to encode response: %v", err)
+		}
+	}
+
+	t.Run("retry on transient 503 then success", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+
+		server := makeServer(func(w http.ResponseWriter, _ *http.Request) {
+			if calls.Add(1) <= 2 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+
+				return
+			}
+
+			okResponse(t, w)
+		})
+		defer server.Close()
+
+		gs := &grafanaSecrets{client: makeClient(server.URL), limiter: testLimiter{}, logger: testLogger}
+		val, err := gs.Get(secretName)
+		require.NoError(t, err)
+		require.Equal(t, secretValue, val)
+		require.EqualValues(t, 3, calls.Load())
+	})
+
+	t.Run("retry exhausted on persistent 503", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+
+		server := makeServer(func(w http.ResponseWriter, _ *http.Request) {
+			calls.Add(1)
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})
+		defer server.Close()
+
+		gs := &grafanaSecrets{client: makeClient(server.URL), limiter: testLimiter{}, logger: testLogger}
+		_, err := gs.Get(secretName)
+		require.ErrorIs(t, err, errTooManyRetries)
+		require.EqualValues(t, maxAttempts, calls.Load())
+	})
+
+	t.Run("retry on 429 with Retry-After header then success", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+
+		server := makeServer(func(w http.ResponseWriter, _ *http.Request) {
+			if calls.Add(1) == 1 {
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(http.StatusTooManyRequests)
+
+				return
+			}
+
+			okResponse(t, w)
+		})
+		defer server.Close()
+
+		gs := &grafanaSecrets{client: makeClient(server.URL), limiter: testLimiter{}, logger: testLogger}
+		val, err := gs.Get(secretName)
+		require.NoError(t, err)
+		require.Equal(t, secretValue, val)
+		require.EqualValues(t, 2, calls.Load())
+	})
+
+	t.Run("retry on 429 without Retry-After header then success", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+
+		server := makeServer(func(w http.ResponseWriter, _ *http.Request) {
+			if calls.Add(1) == 1 {
+				w.WriteHeader(http.StatusTooManyRequests)
+
+				return
+			}
+
+			okResponse(t, w)
+		})
+		defer server.Close()
+
+		gs := &grafanaSecrets{client: makeClient(server.URL), limiter: testLimiter{}, logger: testLogger}
+		val, err := gs.Get(secretName)
+		require.NoError(t, err)
+		require.Equal(t, secretValue, val)
+		require.EqualValues(t, 2, calls.Load())
+	})
+
+	t.Run("non-retriable 401 returns error immediately", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+
+		server := makeServer(func(w http.ResponseWriter, _ *http.Request) {
+			calls.Add(1)
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+		defer server.Close()
+
+		gs := &grafanaSecrets{client: makeClient(server.URL), limiter: testLimiter{}, logger: testLogger}
+		_, err := gs.Get(secretName)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errFailedToGetSecret)
+		require.NotErrorIs(t, err, errTooManyRetries)
+		require.EqualValues(t, 1, calls.Load())
+	})
+
+	t.Run("non-retriable 404 returns error immediately", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+
+		server := makeServer(func(w http.ResponseWriter, _ *http.Request) {
+			calls.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+		})
+		defer server.Close()
+
+		gs := &grafanaSecrets{client: makeClient(server.URL), limiter: testLimiter{}, logger: testLogger}
+		_, err := gs.Get(secretName)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errFailedToGetSecret)
+		require.NotErrorIs(t, err, errTooManyRetries)
+		require.EqualValues(t, 1, calls.Load())
+	})
+
+	t.Run("Retry-After exceeds budget returns errTooManyRetries", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+
+		server := makeServer(func(w http.ResponseWriter, _ *http.Request) {
+			calls.Add(1)
+			w.Header().Set("Retry-After", "999")
+			w.WriteHeader(http.StatusTooManyRequests)
+		})
+		defer server.Close()
+
+		gs := &grafanaSecrets{client: makeClient(server.URL), limiter: testLimiter{}, logger: testLogger}
+		_, err := gs.Get(secretName)
+		require.ErrorIs(t, err, errTooManyRetries)
+		require.EqualValues(t, 1, calls.Load())
+	})
+
+	t.Run("network error retried then success", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+
+		server := makeServer(func(w http.ResponseWriter, _ *http.Request) {
+			if calls.Add(1) == 1 {
+				hijacker, ok := w.(http.Hijacker)
+				if !ok {
+					t.Errorf("response writer is not a Hijacker")
+
+					return
+				}
+
+				conn, _, err := hijacker.Hijack()
+				if err != nil {
+					t.Errorf("hijack failed: %v", err)
+
+					return
+				}
+
+				_ = conn.Close()
+
+				return
+			}
+
+			okResponse(t, w)
+		})
+		defer server.Close()
+
+		gs := &grafanaSecrets{client: makeClient(server.URL), limiter: testLimiter{}, logger: testLogger}
+		val, err := gs.Get(secretName)
+		require.NoError(t, err)
+		require.Equal(t, secretValue, val)
+		require.EqualValues(t, 2, calls.Load())
+	})
+
+	t.Run("network error exhausted does not return errTooManyRetries", func(t *testing.T) {
+		t.Parallel()
+
+		// Point the client at a port that should refuse all connections.
+		// The transport error returned from every attempt must take the
+		// default branch in Get, not the retryError branch.
+		gs := &grafanaSecrets{client: makeClient("http://127.0.0.1:1"), limiter: testLimiter{}, logger: testLogger}
+		_, err := gs.Get(secretName)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, errTooManyRetries)
+	})
 }
 
 func valToPtr[T any](v T) *T { return &v }


### PR DESCRIPTION
Since Get is communicating with a remote service, there's a chance the request will fail.

This will retry the request for some HTTP status codes and pass up the error for others.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior of secret retrieval by adding retries, per-attempt timeouts, and new error classification, which could affect latency and failure modes under load or misconfigured retry headers.
> 
> **Overview**
> Secret retrieval (`grafanaSecrets.Get`) now retries transient failures using exponential backoff with a per-attempt timeout, including special handling for `429` responses via `Retry-After` and a new `errTooManyRetries` terminal error.
> 
> Adds supporting helpers (`retry`, `parseRetryAfter`, `retryError`) and expands tests to cover retriable/non-retriable HTTP statuses, `Retry-After` budget exhaustion, and network error scenarios; promotes `github.com/cenkalti/backoff/v5` to a direct dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f53508908646dc349f4c9a0e7a966e46f1b8e646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->