### PR TITLE
test: retry createSession on 5xx to deflake browser integration

### DIFF
--- a/integration/integration_browserutils_test.go
+++ b/integration/integration_browserutils_test.go
@@ -138,10 +138,39 @@ type sessionInfo struct {
 }
 
 // createSession uses the crocochrome API to start a browser session.
+// It retries on 5xx responses to absorb transient chromium cold-start failures
+// (chromium occasionally gets SIGKILL'd within a few hundred ms of spawn on
+// shared CI runners; the next session on the same crocochrome usually works).
 func createSession(endpoint string) (*sessionInfo, error) {
+	const attempts = 3
+
+	const backoff = time.Second
+
+	var lastErr error
+
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if attempt > 1 {
+			time.Sleep(backoff)
+		}
+
+		session, status, err := doCreateSession(endpoint)
+		if err == nil {
+			return session, nil
+		}
+
+		lastErr = err
+		if status < 500 {
+			return nil, err
+		}
+	}
+
+	return nil, fmt.Errorf("after %d attempts: %w", attempts, lastErr)
+}
+
+func doCreateSession(endpoint string) (*sessionInfo, int, error) {
 	resp, err := http.Post(endpoint+"/sessions", "application/json", nil) //nolint:noctx // Test helper.
 	if err != nil {
-		return nil, fmt.Errorf("posting session: %w", err)
+		return nil, 0, fmt.Errorf("posting session: %w", err)
 	}
 
 	defer resp.Body.Close()
@@ -150,17 +179,17 @@ func createSession(endpoint string) (*sessionInfo, error) {
 		body, _ := io.ReadAll(resp.Body)
 
 		//nolint:err113 // No need for static error in test helper.
-		return nil, fmt.Errorf("got unexpected status %d:\n%s", resp.StatusCode, string(body))
+		return nil, resp.StatusCode, fmt.Errorf("got unexpected status %d:\n%s", resp.StatusCode, string(body))
 	}
 
 	session := sessionInfo{}
 
 	err = json.NewDecoder(resp.Body).Decode(&session)
 	if err != nil {
-		return nil, fmt.Errorf("decoding session: %w", err)
+		return nil, resp.StatusCode, fmt.Errorf("decoding session: %w", err)
 	}
 
-	return &session, nil
+	return &session, resp.StatusCode, nil
 }
 
 // deleteSession calls the crocochrome API to delete a session.


### PR DESCRIPTION
## Summary
- `TestSMK6Browser/default_settings` intermittently fails on self-hosted runners because crocochrome's chromium process gets SIGKILL'd within a few hundred ms of spawn (e.g. [this run](https://github.com/grafana/xk6-sm/actions/runs/26108385141/job/76961735977) — 3rd attempt of the same run).
- Subsequent subtests on the *same* crocochrome instance succeed, so a small retry around session creation is enough.
- 3 attempts with 1s backoff, only on 5xx — 4xx/transport errors propagate immediately so genuine bugs aren't masked.

## Failure mode being fixed
```
integration_test.go:512: creating crocochrome session: got unexpected status 500:
    retries exhausted trying to reach chromium: context deadline exceeded
```
Chromium logs from the same job show `"err":"signal: killed","exitCode":-1` ~330ms into startup.

## Test plan
- [x] `make lint-go` passes
- [x] `go vet ./...` passes
- [x] Integration tests still compile (`go test -run '^$' ./integration/...`)
- [ ] Confirm CI passes on this PR (the original flake should no longer reproduce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)