### PR TITLE
fix: Pass github token in environment

### DIFF
--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -164,6 +164,7 @@ jobs:
 
       - name: upload artifact to release
         env:
+          GH_TOKEN: ${{ github.token }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |-
           ./scripts/release-binaries "${GITHUB_REF_NAME}"


### PR DESCRIPTION
I mistakenly thought GH_TOKEN was already in the environment with this setup.
    
Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>